### PR TITLE
implement our own expand_path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,22 +453,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "path-absolutize"
-version = "3.0.6"
+name = "path-clean"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6ab2aaa5faefed84db46e4398eab15fa51325606462b5da8b0e230af3ac59a"
-dependencies = [
- "path-dedot",
-]
-
-[[package]]
-name = "path-dedot"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658c6e985fce9c25289fe7c86c08a3cbe82c19a3cd5b3bc5945c8c632552e460"
-dependencies = [
- "once_cell",
-]
+checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
 
 [[package]]
 name = "plotters"
@@ -818,7 +806,7 @@ dependencies = [
  "filetime",
  "ignore",
  "log",
- "path-absolutize",
+ "path-clean",
  "rayon",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ console = "0.13"
 filetime = "0.2"
 ignore = "0.4.17"
 log = "0.4"
+path-clean = "0.1.0"
 rayon = "1.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -19,12 +20,6 @@ sha-1 = "0.9.2"
 structopt = "0.3"
 toml = "0.5"
 which = "4.0.2"
-
-[dependencies.path-absolutize]
-version = "3.0.6"
-# Do not use `std::env::set_current_dir`.
-# See https://github.com/magiclen/path-absolutize#once_cell_cache
-features = ["once_cell_cache"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -7,7 +7,7 @@ mod init;
 use self::format::format_cmd;
 use self::init::init_cmd;
 use super::customlog::LogLevel;
-use path_absolutize::*;
+use crate::expand_path;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -46,10 +46,11 @@ pub struct Cli {
 /// Use this instead of Cli::from_args(). We do a little bit of post-processing here.
 pub fn cli_from_args() -> anyhow::Result<Cli> {
     let mut cli = Cli::from_args();
+    let cwd = std::env::current_dir()?;
+    assert!(cwd.is_absolute());
     // Make sure the work_dir is an absolute path. Don't use the stdlib canonicalize() function
     // because symlinks should not be resolved.
-    let abs_work_dir = cli.work_dir.absolutize()?;
-    cli.work_dir = abs_work_dir.to_path_buf();
+    cli.work_dir = expand_path(&cli.work_dir, &cwd);
     Ok(cli)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod eval_cache;
 use crate::eval_cache::{get_mtime, Mtime};
 use anyhow::Result;
 use customlog::CustomLogOutput;
+use path_clean::PathClean;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
@@ -147,3 +148,14 @@ impl PartialEq for FileMeta {
 }
 
 impl Eq for FileMeta {}
+
+/// Returns an absolute path. If the path is absolute already, leave it alone. Otherwise join it to the reference path.
+/// Then clean all superfluous ../
+pub fn expand_path(path: &PathBuf, reference: &PathBuf) -> PathBuf {
+    let new_path = if path.is_absolute() {
+        path.clone()
+    } else {
+        reference.join(path)
+    };
+    new_path.clean()
+}


### PR DESCRIPTION
path-absolutize's absolutize_virtually was actually failing if path is
already absolute and not under the reference directory. But we just want
to expand the path and make sure it's absolute and clean.