### PR TITLE
cli: format the whole tree by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ FLAGS:
 OPTIONS:
         --log-level <log-level>    The maximum level of messages that should be logged by treefmt. [possible values:
                                    info, warn, error] [default: debug]
-        --tree-root <tree-root>    Set the location of the tree root. Defaults to the location of the treefmt.toml file
+        --tree-root <tree-root>    Set the path to the tree root directory. Defaults to the folder holding the
+                                   treefmt.toml file
     -C <work-dir>                  Run as if treefmt was started in <work-dir> instead of the current working directory
                                    [default: .]
 
 ARGS:
-    <paths>...    Paths to format [default: .]
+    <paths>...    Paths to format. Defaults to formatting the whole tree
 ```
 
 ## Configuration format

--- a/src/command/format.rs
+++ b/src/command/format.rs
@@ -39,6 +39,13 @@ pub fn format_cmd(
         config_file.clone().parent().unwrap().to_path_buf()
     });
 
+    // Default to the tree root if no paths have been given
+    let paths = if paths.is_empty() {
+        vec![tree_root.clone()]
+    } else {
+        paths.to_owned()
+    };
+
     let cache_dir = proj_dirs.cache_dir().join("eval-cache");
     // Make sure the cache directory exists.
     fs::create_dir_all(&cache_dir)?;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -50,8 +50,8 @@ pub struct Cli {
     /// Set the path to the tree root directory. Defaults to the folder holding the treefmt.toml file.
     pub tree_root: Option<PathBuf>,
 
-    #[structopt(default_value = ".")]
-    /// Paths to format
+    #[structopt()]
+    /// Paths to format. Defaults to formatting the whole tree.
     pub paths: Vec<PathBuf>,
 }
 


### PR DESCRIPTION
Instead of formatting the current directory, format the whole tree if no
paths are given.

Use `treefmt .` to format the current folder.

That way it's less likely that some files will not be re-formatted, even
if the user is working in a sub-folder.