### PR TITLE
customlog: use the log facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,11 @@ FLAGS:
         --fail-on-change    Exit with error if any changes were made. Useful for CI
     -h, --help              Prints help information
         --init              Create a new treefmt.toml
-    -q, --quiet             No output printed to stdout
+    -q, --quiet             No output printed to stderr
     -V, --version           Prints version information
     -v, --verbose           Log verbosity is based off the number of v used
 
 OPTIONS:
-        --log-level <log-level>    The maximum level of messages that should be logged by treefmt. [possible values:
-                                   info, warn, error] [default: debug]
         --tree-root <tree-root>    Set the path to the tree root directory. Defaults to the folder holding the
                                    treefmt.toml file
     -C <work-dir>                  Run as if treefmt was started in <work-dir> instead of the current working directory

--- a/src/command/format.rs
+++ b/src/command/format.rs
@@ -1,8 +1,8 @@
 use crate::config;
 use crate::engine::run_treefmt;
-use crate::CLOG;
 use anyhow::anyhow;
 use directories::ProjectDirs;
+use log::debug;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -51,14 +51,14 @@ pub fn format_cmd(
     // Make sure the cache directory exists.
     fs::create_dir_all(&cache_dir)?;
 
-    CLOG.debug(&format!(
+    debug!(
         "tree_root={} work_dir={} cache_dir={} config_file={} paths={:?}",
         tree_root.display(),
         work_dir.display(),
         cache_dir.display(),
         config_file.display(),
         paths
-    ));
+    );
 
     // Finally run the main formatter logic from the engine.
     run_treefmt(

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -1,7 +1,7 @@
 use crate::config;
-use crate::CLOG;
 use anyhow::Context;
 use console::style;
+use log::info;
 use std::fs;
 use std::path::Path;
 
@@ -31,9 +31,6 @@ excludes = []
         )
     })?;
 
-    CLOG.info(&format!(
-        "Generated treefmt template at {}",
-        file_path.display()
-    ));
+    info!("Generated treefmt template at {}", file_path.display());
     Ok(())
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -6,7 +6,6 @@ mod init;
 
 use self::format::format_cmd;
 use self::init::init_cmd;
-use super::customlog::LogLevel;
 use crate::expand_path;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -39,12 +38,8 @@ pub struct Cli {
     pub verbosity: u8,
 
     #[structopt(long = "quiet", short = "q")]
-    /// No output printed to stdout
+    /// No output printed to stderr
     pub quiet: bool,
-
-    #[structopt(long = "log-level", default_value = "debug")]
-    /// The maximum level of messages that should be logged by treefmt. [possible values: info, warn, error]
-    pub log_level: LogLevel,
 
     #[structopt(short = "C", default_value = ".")]
     /// Run as if treefmt was started in <work-dir> instead of the current working directory.

--- a/src/eval_cache.rs
+++ b/src/eval_cache.rs
@@ -2,10 +2,11 @@
 use crate::{
     customlog,
     formatter::{Formatter, FormatterName},
-    get_path_mtime, Mtime, CLOG,
+    get_path_mtime, Mtime,
 };
 
 use anyhow::Result;
+use log::{debug, error, warn};
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
 use std::fs::{read_to_string, File};
@@ -61,7 +62,7 @@ impl CacheManifest {
     /// Loads the manifest and returns an error if it failed
     pub fn try_load(cache_dir: &Path, treefmt_toml: &Path) -> Result<Self> {
         let manifest_path = get_manifest_path(cache_dir, treefmt_toml);
-        CLOG.debug(&format!("cache: loading from {}", manifest_path.display()));
+        debug!("cache: loading from {}", manifest_path.display());
         let content = read_to_string(&manifest_path)?;
         let manifest = toml::from_str(&content)?;
         Ok(manifest)
@@ -73,10 +74,7 @@ impl CacheManifest {
         match Self::try_load(cache_dir, treefmt_toml) {
             Ok(manifest) => manifest,
             Err(err) => {
-                CLOG.warn(&format!(
-                    "cache: failed to load the manifest due to: {}",
-                    err
-                ));
+                warn!("cache: failed to load the manifest due to: {}", err);
                 Self::default()
             }
         }
@@ -85,7 +83,7 @@ impl CacheManifest {
     /// Seralizes back the manifest into place.
     pub fn try_write(self, cache_dir: &Path, treefmt_toml: &Path) -> Result<()> {
         let manifest_path = get_manifest_path(cache_dir, treefmt_toml);
-        CLOG.debug(&format!("cache: writing to {}", manifest_path.display()));
+        debug!("cache: writing to {}", manifest_path.display());
         let mut f = File::create(manifest_path)?;
         f.write_all(
             format!(
@@ -102,7 +100,7 @@ impl CacheManifest {
     /// Seralizes back the manifest into place.
     pub fn write(self, cache_dir: &Path, treefmt_toml: &Path) {
         if let Err(err) = self.try_write(cache_dir, treefmt_toml) {
-            CLOG.warn(&format!("cache: failed to write to disk: {}", err));
+            warn!("cache: failed to write to disk: {}", err);
         };
     }
 
@@ -127,7 +125,7 @@ impl CacheManifest {
                 Err(err) => {
                     // TODO: This probably means that there is a deeper issue with the formatter and
                     //       the formatter will fail down the line.
-                    CLOG.error(&format!("cache: failed to load the formatter info {}", err))
+                    error!("cache: failed to load the formatter info {}", err)
                 }
             }
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,9 +1,9 @@
 //! Utilities for the formatters themselves.
 use crate::config::FmtConfig;
-use crate::CLOG;
 use crate::{expand_if_path, expand_path};
 use anyhow::{anyhow, Result};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+use log::debug;
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -126,11 +126,7 @@ impl Formatter {
         let work_dir = expand_path(&cfg.work_dir, tree_root);
         // Resolve the path to the binary
         let command = which(&cfg.command)?;
-        CLOG.debug(&format!(
-            "Found {} at {}",
-            cfg.command.display(),
-            command.display()
-        ));
+        debug!("Found {} at {}", cfg.command.display(), command.display());
         assert!(command.is_absolute());
 
         // Build the include and exclude globs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,16 +9,12 @@ pub mod eval_cache;
 pub mod formatter;
 
 use anyhow::Result;
-use customlog::CustomLogOutput;
 use filetime::FileTime;
 use path_clean::PathClean;
 use serde::{Deserialize, Serialize};
 use std::fs::Metadata;
 use std::path::PathBuf;
 use std::{fmt, path::Path};
-
-/// The global custom log and user-facing message output.
-pub static CLOG: CustomLogOutput = CustomLogOutput::new();
 
 /// Mtime represents a unix epoch file modification time
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Copy, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,17 @@
 #![allow(clippy::redundant_closure, clippy::redundant_pattern_matching)]
 
+use log::error;
 use treefmt::command::{cli_from_args, run_cli};
-use treefmt::CLOG;
+use treefmt::customlog::CUSTOM_LOG;
 
 fn main() {
+    // Configure the logger
+    log::set_logger(&CUSTOM_LOG).expect("Could not set the logger");
+    // The default log level
+    log::set_max_level(log::LevelFilter::Debug);
+
     if let Err(e) = run() {
-        CLOG.error(&format!("{}", e));
+        error!("{}", e);
         ::std::process::exit(1);
     }
 }
@@ -13,10 +19,10 @@ fn main() {
 fn run() -> anyhow::Result<()> {
     let cli = cli_from_args()?;
 
-    CLOG.set_log_level(cli.log_level);
-
     if cli.quiet {
-        CLOG.set_quiet(true);
+        log::set_max_level(log::LevelFilter::Off)
+    } else if cli.verbosity > 0 {
+        log::set_max_level(log::LevelFilter::Trace)
     }
 
     run_cli(&cli)?;


### PR DESCRIPTION
Instead of calling CLOG directly, use the "log" crate on the producer
side, and then plug CLOG as a consumer. This allows for some nice
decoupling and the log macros are also nicer on the eye.

--log-level has disappeared for now

Thanks to @ldesgoui for the suggestion.