### PR TITLE
Report formatter output on error

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -2,6 +2,7 @@
 use crate::config::FmtConfig;
 use crate::{expand_if_path, expand_path};
 use anyhow::{anyhow, Result};
+use console::style;
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use log::debug;
 use path_clean::PathClean;
@@ -96,6 +97,14 @@ impl Formatter {
         match cmd_arg.output() {
             Ok(out) => {
                 if !out.status.success() {
+                    debug!(
+                        "Error using formatter {}:\n{stdout}:\n{}\n{stderr}:\n{}",
+                        self.name,
+                        String::from_utf8_lossy(&out.stdout),
+                        String::from_utf8_lossy(&out.stderr),
+                        stdout = style("• [STDOUT]").bold().dim(),
+                        stderr = style("• [STDERR]").bold().dim(),
+                    );
                     match out.status.code() {
                         Some(scode) => {
                             return Err(anyhow!(


### PR DESCRIPTION
fixes #103 

Show `stdout` and `stderr` of the formatter when it errors out.

To simulate a formatter error I have been using:

```diff
diff --git a/treefmt.toml b/treefmt.toml
index 2b5fb94..99f55e6 100644
--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,7 +1,8 @@
 # One CLI to format the code tree - https://github.com/numtide/treefmt

 [formatter.python]
-command = "black"
+command = "bash"
+options = ["-c", "echo $1; >&2 echo This is an error; exit 1", "--"]
 includes = ["*.py"]

 [formatter.elm]
 ```

This results in the following output:

```bash
🐛 [DEBUG]: Error using formatter #python:
• [STDOUT]:
/home/basile/dev/treefmt/examples/python/main.py

• [STDERR]:
This is an error

ℹ️ [INFO]: #elm: 1 files processed in 38.89ms
ℹ️ [INFO]: #rust: 13 files processed in 73.00ms
⛔ [ERR]: #python's formatter failed: exit status 1
```