### PR TITLE
Always expanding the path given in the treefmt.toml

### DIFF
--- a/devshell.toml
+++ b/devshell.toml
@@ -17,6 +17,7 @@ packages = [
   "elmPackages.elm-format",
   "go",
   "haskellPackages.ormolu",
+  "haskellPackages.cabal-fmt",
   "nixpkgs-fmt",
   "nodePackages.prettier",
   "python3.pkgs.black",

--- a/examples/haskell/Foo.hs
+++ b/examples/haskell/Foo.hs
@@ -1,0 +1,4 @@
+module Foo where
+
+foo :: IO ()
+foo = putStrLn "Hello, Riyan!"

--- a/examples/haskell/Nested/Foo.hs
+++ b/examples/haskell/Nested/Foo.hs
@@ -1,0 +1,4 @@
+module Nested.Foo where
+
+foo :: IO ()
+foo = putStrLn "Hello, Riyan!"

--- a/examples/haskell/treefmt.toml
+++ b/examples/haskell/treefmt.toml
@@ -1,0 +1,10 @@
+[formatter.haskell]
+command = "ormolu"
+options = [
+    "--ghc-opt", "-XBangPatterns",
+    "--ghc-opt", "-XPatternSynonyms",
+    "--ghc-opt", "-XTypeApplications",
+    "--mode", "inplace",
+    "--check-idempotence",
+]
+includes = ["Foo.hs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,3 +60,79 @@ pub fn expand_if_path(str: String, reference: &Path) -> String {
         format!("*/{}",str)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path};
+    use globset::{GlobBuilder, GlobSetBuilder};
+    use super::expand_if_path;
+    
+    
+    #[test]
+    fn test_expand_if_path_single_pattern() {
+        let path = vec![
+            "/Foo.hs",
+            "/nested/Foo.hs",
+            "/nested/nested_again/Foo.hs",
+            "/different_folder/Foo.hs",
+            "/nested/different_folder/Foo.hs",
+        ];
+        let pattern = "Foo.hs";
+        let mut sum = GlobSetBuilder::new();
+        let tree_root = Path::new("/");
+        let pat = expand_if_path(pattern.to_string(), &tree_root);
+        let glob = GlobBuilder::new(&pat).build().unwrap();
+        sum.add(glob);
+        let result = sum.build().unwrap();
+        let test = path.clone().into_iter().filter(|p| result.is_match(p)).collect::<Vec<&str>>();
+
+        assert_eq!(path, test);
+    }
+
+    #[test]
+    fn test_expand_if_path_wildcard() {
+        let path = vec![
+            "/Foo.hs",
+            "/nested/Foo.hs",
+            "/nested/nested_again/Foo.hs",
+            "/different_folder/Foo.hs",
+            "/nested/different_folder/Foo.hs",
+            "/nested/Bar.hs",
+            "/nested/different_folder/Bar.hs"
+        ];
+        
+        let pattern = "*.hs";
+        let mut sum = GlobSetBuilder::new();
+        let tree_root = Path::new("/");
+        let pat = expand_if_path(pattern.to_string(), &tree_root);
+        let glob = GlobBuilder::new(&pat).build().unwrap();
+        sum.add(glob);
+        let result = sum.build().unwrap();
+        let test = path.clone().into_iter().filter(|p| result.is_match(p)).collect::<Vec<&str>>();
+
+        assert_eq!(path, test);
+    }
+    
+    #[test]
+    fn test_expand_if_path_single_pattern_with_slash() {
+        let path = vec![
+            "/Foo.hs",
+            "/nested/Foo.hs",
+            "/nested/nested_again/Foo.hs",
+            "/different_folder/Foo.hs",
+            "/nested/different_folder/Foo.hs",
+            "/nested/Bar.hs",
+            "/nested/different_folder/Bar.hs"
+        ];
+        let pattern = "nested/Foo.hs";
+        let mut sum = GlobSetBuilder::new();
+        let tree_root = Path::new("/");
+        let pat = expand_if_path(pattern.to_string(), &tree_root);
+        let glob = GlobBuilder::new(&pat).build().unwrap();
+        sum.add(glob);
+        let result = sum.build().unwrap();
+        let test = path.into_iter().filter(|p| result.is_match(p)).collect::<Vec<&str>>();
+        
+        assert_eq!(vec!["/nested/Foo.hs"], test);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,9 @@ pub fn expand_path(path: &Path, reference: &Path) -> PathBuf {
     new_path.clean()
 }
 
-/// Only expands the path if the string contains a slash (/) in it. Otherwise consider it as a string.
+/// Always expand the path that set in treefmt.toml
 pub fn expand_if_path(str: String, reference: &Path) -> String {
-    if str.contains('/') {
-        expand_path(Path::new(&str), reference)
-            .to_string_lossy()
-            .to_string()
-    } else {
-        str
-    }
+    expand_path(Path::new(&str), reference)
+        .to_string_lossy()
+        .to_string()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,13 @@ pub fn expand_path(path: &Path, reference: &Path) -> PathBuf {
     new_path.clean()
 }
 
-/// Always expand the path that set in treefmt.toml
+/// Only expands the path if the string contains a slash (/) in it. Otherwise consider it as a string.
 pub fn expand_if_path(str: String, reference: &Path) -> String {
-    expand_path(Path::new(&str), reference)
-        .to_string_lossy()
-        .to_string()
+    if str.contains('/') {
+        expand_path(Path::new(&str), reference)
+            .to_string_lossy()
+            .to_string()
+    } else {
+        format!("*/{}",str)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ mod tests {
         let path = vec![
             "/Foo.hs",
             "/nested/Foo.hs",
-            "/nested/nested_again/Foo.hs",
+            "/nested/nested/Foo.hs",
             "/different_folder/Foo.hs",
             "/nested/different_folder/Foo.hs",
             "/nested/Bar.hs",

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -23,8 +23,8 @@ options = [
     "--mode", "inplace",
     "--check-idempotence",
 ]
-includes = ["*.hs"]
-excludes = ["examples/haskell/"]
+includes = ["Foo.hs"]
+
 
 [formatter.nix]
 command = "nixpkgs-fmt"

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -23,8 +23,8 @@ options = [
     "--mode", "inplace",
     "--check-idempotence",
 ]
-includes = ["Foo.hs"]
-
+includes = ["*.hs"]
+excludes = ["examples/haskell/"]
 
 [formatter.nix]
 command = "nixpkgs-fmt"


### PR DESCRIPTION
As discussed, since all path is absolute, then we should always expand the path in the `treefmt.toml`

 fixes #102 and #82