### PR TITLE
More concise stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 result
 result-*
+.idea

--- a/devshell.toml
+++ b/devshell.toml
@@ -13,6 +13,8 @@ packages = [
   # Build tools
   "rust-analyzer",
 
+  "rust.packages.stable.rustPlatform.rustLibSrc",
+
   # Code formatters
   "elmPackages.elm-format",
   "go",
@@ -31,3 +33,4 @@ packages = [
 [[env]]
 name = "PATH"
 eval = "$PWD/target/debug:$PATH"
+


### PR DESCRIPTION
Changes the current output...

```
traversed 1222 files
matched 677 files to formatters
left with 2 files after cache
of whom 0 files were re-formatted
all of this in 173.44ms
```

...to a more concise format

```
0 file(s) changed (processed 1222 file(s) in 173ms)
```

Closes #125 

