### PR TITLE
Trade in naersk for a newer version of nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,13 +13,15 @@ let
     pkgs = nixpkgs;
   };
 
-  naersk = nixpkgs.callPackage inputs.naersk { };
+  cargoToml = with builtins; (fromTOML (readFile ./Cargo.toml));
 in
 {
   # What is used when invoking `nix run github:numtide/treefmt`
-  treefmt = naersk.buildPackage
+  treefmt = nixpkgs.pkgs.rustPlatform.buildRustPackage
     {
       src = nixpkgs.lib.cleanSource ./.;
+      inherit (cargoToml.package) name version;
+      cargoLock.lockFile = ./Cargo.lock;
     } // { meta.description = "one CLI to format the code tree"; };
 
   # A collection of packages for the project

--- a/flake.lock
+++ b/flake.lock
@@ -30,45 +30,26 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1612192764,
-        "narHash": "sha256-7EnLtZQWP6511G1ZPA7FmJlqAr3hWsAYb24tvTvJ/ec=",
-        "owner": "nmattia",
-        "repo": "naersk",
-        "rev": "6e149bfd726a8ebefa415f2d713ba6d942435abd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nmattia",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1613418107,
-        "narHash": "sha256-UVG9gUzg9vZfmyLvz9pNUk1qxUWxHCZJWUULjlgxFTk=",
+        "lastModified": 1636470166,
+        "narHash": "sha256-0tyWSS5rgMtML5p41ZdE5ocuAnRdtOGvdsqQyMUBYAI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "69d5df6303374e52f56eb57fa0ed38793ed03718",
+        "rev": "f096b7122ab08e93c8b052c92461ca71b80c0cc8",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
         "devshell": "devshell",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock.nix
+++ b/flake.lock.nix
@@ -96,7 +96,7 @@ let
                 (resolveInput lockFile.nodes.${nodeName}.inputs.${builtins.head path})
                 (builtins.tail path);
 
-          result = sourceInfo // { inherit inputs;inherit sourceInfo; };
+          result = sourceInfo // { inherit inputs; inherit sourceInfo; };
         in
         if node.flake or true then
           result

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,11 @@
   description = "treefmt";
   # To update all inputs:
   # $ nix flake update --recreate-lock-file
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.devshell.url = "github:numtide/devshell";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.naersk.inputs.nixpkgs.follows = "nixpkgs";
-  inputs.naersk.url = "github:nmattia/naersk";
 
-  outputs = { self, nixpkgs, naersk, flake-utils, devshell }@inputs:
+  outputs = { self, nixpkgs, flake-utils, devshell }@inputs:
     flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
       let pkgs = import ./. { inherit system inputs; }; in
       {


### PR DESCRIPTION
- Naersk has the annoying property to pin nixpkgs as a dep
- Nixpkgs mostly is a _core_ dependency that it is worth auditing duely
  (e.g. to avoid cache mismatches and other spourious errors)
- Every usage of naersk adds a another "spurious" nixpkgs dep somewhere
  to the flake lock. That makes auditing less straight forward.
