### PR TITLE
Add support for `.treefmt.toml`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ use std::{collections::BTreeMap, path::Path};
 
 /// Name of the config file
 pub const FILENAME: &str = "treefmt.toml";
+/// Alternative name of the config file
+pub const FILENAMEALT: &str = ".treefmt.toml";
 
 /// treefmt.toml structure
 #[derive(Debug, Deserialize)]
@@ -55,8 +57,11 @@ pub fn lookup(dir: &Path) -> Option<PathBuf> {
     let mut cwd = dir.to_path_buf();
     loop {
         let config_file = cwd.join(FILENAME);
+        let config_file_alt = cwd.join(FILENAMEALT);
         if config_file.exists() {
             return Some(config_file);
+        } else if config_file_alt.exists() {
+            return Some(config_file_alt);
         }
         cwd = match cwd.parent() {
             Some(x) => x.to_path_buf(),


### PR DESCRIPTION
This adds support for a configuration file `.treefmt.toml` in addition to the default `treefmt.toml`. If both are found, only the `treefmt.toml` is accepted. I could also raise an error in that case.

Most of the formatters support dotfiles as configuration file (which I prefer), I figured out that the project could benefit from this option.