### PR TITLE
Make `treefmt.withConfig` work independent of $PRJ_ROOT

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,1 @@
-export PRJ_ROOT=$PWD
 use nix

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,8 @@
 
         # In Nix 2.8 you can run `nix fmt` to format this whole repo. Note that you need to have loaded the
         # `nix develop` shell before so the various formatters are available in the PATH.
-        # It also assumes that the PRJ_ROOT environment variable is set that points to the project root.
-        formatter = pkgs.treefmt.withConfig (nixpkgs.lib.importTOML ./treefmt.toml);
+        # It also assumes that the project root has a flake.nix (override this by setting `projectRootFile`).
+        formatter = pkgs.treefmt.withConfig { config = nixpkgs.lib.importTOML ./treefmt.toml; };
 
         devShell = pkgs.devShell;
       }


### PR DESCRIPTION
https://github.com/numtide/treefmt/pull/169#issuecomment-1219213800