### PR TITLE
feat: hard fail on missing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ USAGE:
     treefmt [FLAGS] [OPTIONS] [paths]...
 
 FLAGS:
-        --clear-cache       Clear the evaluation cache. Use in case the cache is not precise enough
-        --fail-on-change    Exit with error if any changes were made. Useful for CI
-    -h, --help              Prints help information
-        --init              Create a new treefmt.toml
-    -q, --quiet             No output printed to stderr
-        --stdin             Format the content passed in stdin
-    -V, --version           Prints version information
-    -v, --verbose           Log verbosity is based off the number of v used
+        --allow-missing-formatter    Do not exit with error if a configured formatter is missing
+        --clear-cache                Clear the evaluation cache. Use in case the cache is not precise enough
+        --fail-on-change             Exit with error if any changes were made. Useful for CI
+    -h, --help                       Prints help information
+        --init                       Create a new treefmt.toml
+    -q, --quiet                      No output printed to stderr
+        --stdin                      Format the content passed in stdin
+    -V, --version                    Prints version information
+    -v, --verbose                    Log verbosity is based off the number of v used
 
 OPTIONS:
         --tree-root <tree-root>    Set the path to the tree root directory. Defaults to the folder holding the

--- a/src/command/format.rs
+++ b/src/command/format.rs
@@ -12,6 +12,7 @@ pub fn format_cmd(
     paths: &[PathBuf],
     clear_cache: bool,
     fail_on_change: bool,
+    allow_missing_formatter: bool,
 ) -> anyhow::Result<()> {
     let proj_dirs = match ProjectDirs::from("com", "NumTide", "treefmt") {
         Some(x) => x,
@@ -69,6 +70,7 @@ pub fn format_cmd(
         &paths,
         clear_cache,
         fail_on_change,
+        allow_missing_formatter,
     )?;
 
     Ok(())

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -35,6 +35,10 @@ pub struct Cli {
     )]
     pub fail_on_change: bool,
 
+    /// Do not exit with error if a configured formatter is missing
+    #[structopt(long = "allow-missing-formatter")]
+    pub allow_missing_formatter: bool,
+
     /// Log verbosity is based off the number of v used
     #[structopt(long = "verbose", short = "v", parse(from_occurrences))]
     pub verbosity: u8,
@@ -85,6 +89,7 @@ pub fn run_cli(cli: &Cli) -> anyhow::Result<()> {
             &cli.paths,
             cli.clear_cache,
             cli.fail_on_change,
+            cli.allow_missing_formatter,
         )?
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -28,6 +28,7 @@ pub fn run_treefmt(
     paths: &[PathBuf],
     clear_cache: bool,
     fail_on_change: bool,
+    allow_missing_formatter: bool,
 ) -> anyhow::Result<()> {
     assert!(tree_root.is_absolute());
     assert!(work_dir.is_absolute());
@@ -80,22 +81,36 @@ pub fn run_treefmt(
 
     timed_debug("load config");
 
-    // Load all the formatter instances from the config. Ignore the ones that failed.
+    // Load all the formatter instances from the config.
+    let mut expected_count = 0;
+
     let formatters = project_config.formatter.into_iter().fold(
         BTreeMap::new(),
         |mut sum, (name, mut fmt_config)| {
+            expected_count += 1;
             fmt_config.excludes.extend_from_slice(&global_excludes);
             match Formatter::from_config(&tree_root, &name, &fmt_config) {
                 Ok(fmt_matcher) => {
                     sum.insert(fmt_matcher.name.clone(), fmt_matcher);
                 }
-                Err(err) => error!("Ignoring formatter #{} due to error: {}", name, err),
+                Err(err) => {
+                    if allow_missing_formatter {
+                        error!("Ignoring formatter #{} due to error: {}", name, err)
+                    } else {
+                        error!("Failed to load formatter #{} due to error: {}", name, err)
+                    }
+                }
             };
             sum
         },
     );
 
     timed_debug("load formatters");
+
+    // Check the number of configured formatters matches the number of formatters loaded
+    if !(allow_missing_formatter || formatters.len() == expected_count) {
+        return Err(anyhow!("One or more formatters are missing"));
+    }
 
     // Load the eval cache
     let mut cache = if clear_cache {


### PR DESCRIPTION
By default if a formatter cannot be loaded you will get output like this:

```shell
[ERR]: Failed to load formatter #go due to error: cannot find binary path
[ERR]: Failed to load formatter #rust due to error: cannot find binary path
[ERR]: One or more formatters are missing
```

You can enable the current behaviour with the flag `--allow-missing-formatter` which will simply log that it will ignore the formatter.

Closes #180 