### PR TITLE
feat: more concise stats

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -321,17 +321,13 @@ fn print_summary(
 ) {
     println!(
         r#"
-traversed {} files
-matched {} files to formatters
-left with {} files after cache
-of whom {} files were re-formatted
-all of this in {:.0?}
+{} files changed in {:.0?} (processed {}, matched {}, cache misses {}) 
         "#,
+        reformatted_files,
+        start_time.elapsed(),
         traversed_files,
         matched_files,
         filtered_files,
-        reformatted_files,
-        start_time.elapsed()
     );
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -336,7 +336,7 @@ fn print_summary(
 ) {
     println!(
         r#"
-{} files changed in {:.0?} (processed {}, matched {}, cache misses {}) 
+{} files changed in {:.0?} (found {}, matched {}, cache misses {}) 
         "#,
         reformatted_files,
         start_time.elapsed(),


### PR DESCRIPTION
Changes the current output...

```
traversed 1222 files
matched 677 files to formatters
left with 2 files after cache
of whom 0 files were re-formatted
all of this in 173.44ms
```

...to a more concise format

```
0 files changed in 173ms (processed 1222, matched 677, cache misses 2)
```

Closes #125 
