### PR TITLE
improve the formatter load error

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -106,7 +106,7 @@ pub fn run_treefmt(
                     if allow_missing_formatter {
                         error!("Ignoring formatter #{} due to error: {}", name, err)
                     } else {
-                        error!("Failed to load formatter #{} due to error: {}", name, err)
+                        error!("Failed to load formatter #{}: {}", name, err)
                     }
                 }
             };

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,7 +1,7 @@
 //! Utilities for the formatters themselves.
 use std::{fmt, path::Path, path::PathBuf, process::Command};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use console::style;
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use log::{debug, warn};
@@ -161,8 +161,10 @@ impl Formatter {
         let name = FormatterName(name.to_string());
         // Expand the work_dir to an absolute path, using the project root as a reference.
         let work_dir = expand_path(&cfg.work_dir, tree_root);
+
         // Resolve the path to the binary
-        let command = expand_exe(&cfg.command, tree_root)?;
+        let command = expand_exe(&cfg.command, tree_root)
+            .with_context(|| format!("could not find '{}' on PATH", &cfg.command))?;
         debug!("Found {} at {}", cfg.command, command.display());
         assert!(command.is_absolute());
 


### PR DESCRIPTION
Display what it was looking for, so it's easier to debug.

Before:

    Failed to load formatter #python due to error: cannot find binary path

After:

    Failed to load formatter #python: could not find 'black' on PATH

This should help with errors like https://github.com/numtide/treefmt-nix/issues/27