### PR TITLE
change default log level to info

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,8 @@ fn run() -> anyhow::Result<()> {
         .format_timestamp(None)
         .format_target(false)
         .filter_level(match cli.verbosity {
-            0 => LevelFilter::Warn,
-            1 => LevelFilter::Info,
-            2 => LevelFilter::Debug,
+            0 => LevelFilter::Info,
+            1 => LevelFilter::Debug,
             _ => LevelFilter::Trace,
         })
         .init();


### PR DESCRIPTION
Info is meant to inform the user. In that case, we want to show how much time each formatter is taking, because it's good for the ecosystem to be aware of how slow each formatter is.