### PR TITLE
flake: expose the list of supported systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,7 +76,8 @@
         "flake-parts": "flake-parts",
         "mkdocs-numtide": "mkdocs-numtide",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
       }
     },
     "rust-overlay": {
@@ -97,6 +98,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1680980633,
+        "narHash": "sha256-mz27VfAExPMYuoWsb1cf++DIyUWWBEbAvXD0BJ+AT/E=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "4e9a51a15ceb27e5141819142a7d2ee827943fc8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,9 @@
   description = "treefmt";
   # To update all inputs:
   # $ nix flake update --recreate-lock-file
+
+  inputs.systems.url = "github:nix-systems/default";
+
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.flake-parts.url = "github:hercules-ci/flake-parts";
   inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
@@ -12,9 +15,9 @@
   inputs.mkdocs-numtide.url = "github:numtide/mkdocs-numtide";
   inputs.mkdocs-numtide.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, flake-parts, mkdocs-numtide, ... }@inputs:
+  outputs = { self, nixpkgs, flake-parts, mkdocs-numtide, systems, ... }@inputs:
     flake-parts.lib.mkFlake { inherit self; } {
-      systems = nixpkgs.lib.systems.flakeExposed;
+      systems = import systems;
       perSystem = { system, pkgs, ... }:
         let
           packages = import ./. {


### PR DESCRIPTION
This commit introduces a new convention that allows consumers of a flake to control systems the flake is built with.

One of the core issues of flakes is that the list of systems that a flake is evaluated with is internal to the flake. Some projects can technically build with more platforms, but to change this, the user has to fork or submit a patch to change the list. Conversely, as a consumer of a flake, you might not care of evaluating the flake with all of the systems, and that list cannot be reduced.

To work around that issue, we introduce a new convention: 
1. If the `systems` input exists, it MUST point to a nix file. 
2. That file SHOULD be named `flake.systems.nix`.
3. That file MUST contain a list of supported systems (list of strings)
4. That input MUST be used by the flake to iterate over the supported systems (see this commit as an example)

With this convention in place, consumers of the flake can now override the list of systems using the input "follows" mechanism like so:

```
inputs.systems.url = "path:./flake.systems.nix";
inputs.systems.flake = false;
inputs.treefmt.url = "github:numtide/treefmt";
inputs.treefmt.inputs.follows.systems = "systems";
```

Invented with the help of @bb010g in https://github.com/numtide/flake-utils/pull/84