### PR TITLE
chore: add tests for the run engine

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -15,6 +15,16 @@ use crate::{expand_exe, expand_if_path, expand_path};
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FormatterName(String);
 
+#[cfg(test)]
+impl FormatterName {
+    pub(crate) fn new<S>(name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self(name.into())
+    }
+}
+
 impl Serialize for FormatterName {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Add tests for the run engine. A particular focus of these tests are
allowing assertions of the relationships between:
- configuration
- directory structure
- walked files
- matched files

What has been done: 
- refactored parts of the run function into it's own methods
- tested these methods
- goal is a pure refactor and no behavioral changes

`cargo tarpaulin`: 
```
src/engine.rs: 69/200 +34.50%
src/formatter.rs: 36/74 +48.65%
```