### PR TITLE
Fix flaky tests that use `std::env::set_var`

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -4,6 +4,7 @@ set -exuo pipefail
 
 # Quick sanity check
 cargo test
+cargo test -- --ignored --test-threads=1
 
 # Check that no code needs reformatting. Acts as a minimal integration test.
 cargo run -- --fail-on-change

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -175,6 +175,7 @@ pub fn run_cli(cli: &Cli) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[ignore = "std::env::set_var: should not be run in parallel."]
     fn current_dir_prefers_pwd_env_var() {
         use crate::command::current_dir;
         use std::env;
@@ -192,6 +193,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "std::env::set_var: should not be run in parallel."]
     fn current_dir_uses_dereferenced_path_when_pwd_env_var_not_set() {
         use crate::command::current_dir;
         use std::env;


### PR DESCRIPTION
Fix flaky tests that use `std::env::set_var`.

`std::env::set_var` is not safe to be used in parallel.

Add `#[ignore]` statements to these tests.
Add an extra test step to `ci.sh`, as I don't think there is a better way mark certain tests as single threaded only.

Reproducer:
```bash
for _ in {0..100}; do
  cargo t current_dir || exit 1
done
```
Will fail very fast.

Doesn't fail:
```bash
for _ in {0..100}; do
  cargo t current_dir_prefers_pwd_env_var || exit 1
  cargo t current_dir_uses_dereferenced_path_when_pwd_env_var_not_set || exit 1
done
```

Reference: https://github.com/rust-lang/rust/issues/27970