### PR TITLE
feat: run the same formatter in parallel for many files

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -123,9 +123,9 @@ pub fn run_treefmt(
                 let start_time = Instant::now();
 
                 // Run the formatter
-                for path_chunks in paths.chunks(1024) {
-                    formatter.clone().fmt(path_chunks)?;
-                }
+                paths.par_chunks(1024).try_for_each(|path_chunks| {
+                    formatter.clone().fmt(path_chunks)
+                })?;
 
                 // Get the new mtimes and compare them to the original ones
                 let new_paths = paths


### PR DESCRIPTION
From the website I'd have thought this would be done already, but after running it over Nixpkgs it turns out it's not.

Parallel formatting seems to originally have been implemented by @basile-henry in https://github.com/numtide/treefmt/pull/17, which subsequently didn't make it in @zimbatm's https://github.com/numtide/treefmt/pull/68. While https://github.com/numtide/treefmt/pull/71 attempted to re-implement it, it only runs each _formatter_ in parallel, but not individual _files_ for the same formatter.

This PR fixes that, making each chunk of 1024 files run in parallel (so no extra parallelism if there's less than that number of files).

I tested this with
```toml
[formatter.nixfmt-rfc-style]
command = "nixfmt"
includes = [ "*.nix" ]
```

with https://github.com/NixOS/nixfmt on https://github.com/nixos/nixpkgs/ and can confirm that it sped it up considerably.

---

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: