### PR TITLE
chore: treefmt

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -123,9 +123,9 @@ pub fn run_treefmt(
                 let start_time = Instant::now();
 
                 // Run the formatter
-                paths.par_chunks(1024).try_for_each(|path_chunks| {
-                    formatter.clone().fmt(path_chunks)
-                })?;
+                paths
+                    .par_chunks(1024)
+                    .try_for_each(|path_chunks| formatter.clone().fmt(path_chunks))?;
 
                 // Get the new mtimes and compare them to the original ones
                 let new_paths = paths


### PR DESCRIPTION
Ran treefmt on itself.

The current main branch has failing `ci` because of it.
I have not yet looked into why it hasn't been caught prior to merging.

Edit: #282 doesn't seem to have the same checks.