### PR TITLE
fix: -f short flag for specifying formatters

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -15,7 +15,7 @@ type Format struct {
 	ClearCache            bool               `short:"c" help:"Reset the evaluation cache. Use in case the cache is not precise enough."`
 	ConfigFile            string             `type:"existingfile" default:"./treefmt.toml" help:"The config file to use."`
 	FailOnChange          bool               `help:"Exit with error if any changes were made. Useful for CI."`
-	Formatters            []string           `help:"Specify formatters to apply. Defaults to all formatters."`
+	Formatters            []string           `short:"f" help:"Specify formatters to apply. Defaults to all formatters."`
 	TreeRoot              string             `type:"existingdir" default:"." help:"The root directory from which treefmt will start walking the filesystem."`
 	Walk                  walk.Type          `enum:"auto,git,filesystem" default:"auto" help:"The method used to traverse the files within --tree-root. Currently supports 'auto', 'git' or 'filesystem'."`
 	Verbosity             int                `name:"verbose" short:"v" type:"counter" default:"0" env:"LOG_LEVEL" help:"Set the verbosity of logs e.g. -vv."`

--- a/cli/format_test.go
+++ b/cli/format_test.go
@@ -106,7 +106,7 @@ func TestSpecifyingFormatters(t *testing.T) {
 	assertStats(t, as, 31, 31, 2, 2)
 
 	setup()
-	_, err = cmd(t, "-c", "--config-file", configPath, "--tree-root", tempDir, "--formatters", "ruby,nix")
+	_, err = cmd(t, "-c", "--config-file", configPath, "--tree-root", tempDir, "-f", "ruby,nix")
 	as.NoError(err)
 	assertStats(t, as, 31, 31, 2, 2)
 


### PR DESCRIPTION
Preserves backwards compatibility with v1

Signed-off-by: Brian McGee <brian@bmcgee.ie>
