### PR TITLE
feat: switch back to numtide/treefmt-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,16 +183,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1714382886,
-        "narHash": "sha256-+gooxbbYcP+MORKQ7W/C2ATvlonW+dyHgCUPnu5dfco=",
-        "owner": "brianmcgee",
+        "lastModified": 1715940852,
+        "narHash": "sha256-wJqHMg/K6X3JGAE9YLM0LsuKrKb4XiBeVaoeMNlReZg=",
+        "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "535e6904c34964ce56d8c092835c11fe6341acc8",
+        "rev": "2fba33a182602b9d49f0b2440513e5ee091d838b",
         "type": "github"
       },
       "original": {
-        "owner": "brianmcgee",
-        "ref": "feat/pipelines",
+        "owner": "numtide",
         "repo": "treefmt-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,7 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
     treefmt-nix = {
-      # todo switch back to numtide/treefmt-nix once merged
-      url = "github:brianmcgee/treefmt-nix/feat/pipelines";
+      url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     devshell = {


### PR DESCRIPTION
It now supports freeform type for settings allowing us to pass through pipeline options.

Signed-off-by: Brian McGee <brian@bmcgee.ie>
