### PR TITLE
fix: restrict github pages publication to releases

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,8 @@ on:
             - main
     pull_request:
     workflow_dispatch:
+    release:
+        types: [released]
 
 permissions:
     contents: write
@@ -41,7 +43,7 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         name: deploy
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'release' && github.event._action == 'released'
         steps:
             - name: Deploy to GitHub Pages
               id: deployment


### PR DESCRIPTION
We currently publish an update when we merge to `main`. This means new functionality that is not yet released is being talked about on the docs site.

This restricts deploying to github pages to releases.


Signed-off-by: Brian McGee <brian@bmcgee.ie>
