### PR TITLE
feat: configure goreleaser to mark releases as pre-release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,10 @@ builds:
           - linux
           - darwin
 
+# marks the release as pre-release
+# this is to prevent noise until we have a stable 2.x
+prerelease: true
+
 changelog:
     sort: asc
     use: github


### PR DESCRIPTION
This is to prevent noise until we have a stable 2.x

Signed-off-by: Brian McGee <brian@bmcgee.ie>
