### PR TITLE
cli: search for the tree root by default

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,7 +13,7 @@ type Format struct {
 	WorkingDirectory      kong.ChangeDirFlag `default:"." short:"C" help:"Run as if treefmt was started in the specified working directory instead of the current working directory."`
 	NoCache               bool               `help:"Ignore the evaluation cache entirely. Useful for CI."`
 	ClearCache            bool               `short:"c" help:"Reset the evaluation cache. Use in case the cache is not precise enough."`
-	ConfigFile            string             `type:"path" help:"Load the config file from the given path (defaults to finding treefmt.toml up)."`
+	ConfigFile            string             `type:"path" help:"Load the config file from the given path (defaults to searching upwards for treefmt.toml)."`
 	FailOnChange          bool               `help:"Exit with error if any changes were made. Useful for CI."`
 	Formatters            []string           `short:"f" help:"Specify formatters to apply. Defaults to all formatters."`
 	TreeRoot              string             `type:"path" help:"The root directory from which treefmt will start walking the filesystem (defaults to the directory containing the config file)."`

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -17,7 +17,7 @@ type Format struct {
 	FailOnChange          bool               `help:"Exit with error if any changes were made. Useful for CI."`
 	Formatters            []string           `short:"f" help:"Specify formatters to apply. Defaults to all formatters."`
 	TreeRoot              string             `type:"existingdir" xor:"tree-root" help:"The root directory from which treefmt will start walking the filesystem (defaults to the directory containing the config file)."`
-	TreeRootFile          string             `type:"path" xor:"tree-root" help:"File to search for to find the project root (if --tree-root is not passed)."`
+	TreeRootFile          string             `type:"string" xor:"tree-root" help:"File to search for to find the project root (if --tree-root is not passed)."`
 	Walk                  walk.Type          `enum:"auto,git,filesystem" default:"auto" help:"The method used to traverse the files within --tree-root. Currently supports 'auto', 'git' or 'filesystem'."`
 	Verbosity             int                `name:"verbose" short:"v" type:"counter" default:"0" env:"LOG_LEVEL" help:"Set the verbosity of logs e.g. -vv."`
 	Version               bool               `name:"version" short:"V" help:"Print version."`

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,10 +13,11 @@ type Format struct {
 	WorkingDirectory      kong.ChangeDirFlag `default:"." short:"C" help:"Run as if treefmt was started in the specified working directory instead of the current working directory."`
 	NoCache               bool               `help:"Ignore the evaluation cache entirely. Useful for CI."`
 	ClearCache            bool               `short:"c" help:"Reset the evaluation cache. Use in case the cache is not precise enough."`
-	ConfigFile            string             `type:"existingfile" default:"./treefmt.toml" help:"The config file to use."`
+	ConfigFile            string             `type:"path" help:"Load the config file from the given path (defaults to finding treefmt.toml up)."`
 	FailOnChange          bool               `help:"Exit with error if any changes were made. Useful for CI."`
 	Formatters            []string           `short:"f" help:"Specify formatters to apply. Defaults to all formatters."`
-	TreeRoot              string             `type:"existingdir" default:"." help:"The root directory from which treefmt will start walking the filesystem."`
+	TreeRoot              string             `type:"path" help:"The root directory from which treefmt will start walking the filesystem (defaults to the directory containing the config file)."`
+	TreeRootFile          string             `type:"path" help:"File to search for to find the project root (if --tree-root is not passed)."`
 	Walk                  walk.Type          `enum:"auto,git,filesystem" default:"auto" help:"The method used to traverse the files within --tree-root. Currently supports 'auto', 'git' or 'filesystem'."`
 	Verbosity             int                `name:"verbose" short:"v" type:"counter" default:"0" env:"LOG_LEVEL" help:"Set the verbosity of logs e.g. -vv."`
 	Version               bool               `name:"version" short:"V" help:"Print version."`

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,7 +13,7 @@ type Format struct {
 	WorkingDirectory      kong.ChangeDirFlag `default:"." short:"C" help:"Run as if treefmt was started in the specified working directory instead of the current working directory."`
 	NoCache               bool               `help:"Ignore the evaluation cache entirely. Useful for CI."`
 	ClearCache            bool               `short:"c" help:"Reset the evaluation cache. Use in case the cache is not precise enough."`
-	ConfigFile            string             `type:"path" help:"Load the config file from the given path (defaults to searching upwards for treefmt.toml)."`
+	ConfigFile            string             `type:"existingfile" help:"Load the config file from the given path (defaults to searching upwards for treefmt.toml)."`
 	FailOnChange          bool               `help:"Exit with error if any changes were made. Useful for CI."`
 	Formatters            []string           `short:"f" help:"Specify formatters to apply. Defaults to all formatters."`
 	TreeRoot              string             `type:"existingdir" xor:"tree-root" help:"The root directory from which treefmt will start walking the filesystem (defaults to the directory containing the config file)."`

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -16,8 +16,8 @@ type Format struct {
 	ConfigFile            string             `type:"path" help:"Load the config file from the given path (defaults to searching upwards for treefmt.toml)."`
 	FailOnChange          bool               `help:"Exit with error if any changes were made. Useful for CI."`
 	Formatters            []string           `short:"f" help:"Specify formatters to apply. Defaults to all formatters."`
-	TreeRoot              string             `type:"path" help:"The root directory from which treefmt will start walking the filesystem (defaults to the directory containing the config file)."`
-	TreeRootFile          string             `type:"path" help:"File to search for to find the project root (if --tree-root is not passed)."`
+	TreeRoot              string             `type:"existingdir" xor:"tree-root" help:"The root directory from which treefmt will start walking the filesystem (defaults to the directory containing the config file)."`
+	TreeRootFile          string             `type:"path" xor:"tree-root" help:"File to search for to find the project root (if --tree-root is not passed)."`
 	Walk                  walk.Type          `enum:"auto,git,filesystem" default:"auto" help:"The method used to traverse the files within --tree-root. Currently supports 'auto', 'git' or 'filesystem'."`
 	Verbosity             int                `name:"verbose" short:"v" type:"counter" default:"0" env:"LOG_LEVEL" help:"Set the verbosity of logs e.g. -vv."`
 	Version               bool               `name:"version" short:"V" help:"Print version."`

--- a/cli/format.go
+++ b/cli/format.go
@@ -81,24 +81,21 @@ func (f *Format) Run() (err error) {
 		}
 	}
 
-	// search for the project root unless specified
+	// default the tree root to the directory containing the config file
 	if Cli.TreeRoot == "" {
-		// use the location of the treefmt.toml file by default
-		dir := filepath.Dir(Cli.ConfigFile)
+		Cli.TreeRoot = filepath.Dir(Cli.ConfigFile)
+	}
 
-		// search using the --tree-root-file if specified
-		if Cli.TreeRootFile != "" {
-			pwd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			_, dir, err = findUp(pwd, Cli.TreeRootFile)
-			if err != nil {
-				return err
-			}
+	// search the tree root using the --tree-root-file if specified
+	if Cli.TreeRootFile != "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return err
 		}
-
-		Cli.TreeRoot = dir
+		_, Cli.TreeRoot, err = findUp(pwd, Cli.TreeRootFile)
+		if err != nil {
+			return err
+		}
 	}
 
 	log.Debugf("config-file=%s tree-root=%s", Cli.ConfigFile, Cli.TreeRoot)


### PR DESCRIPTION
Restore the treefmt 1.x behaviour where it would search for the tree root by recursively searching for the treefmt.toml file up the filesystem, starting from the current directory.

The `--tree-root-file` option will be useful to remove this bash wrapper: https://github.com/numtide/treefmt-nix/blob/2fba33a182602b9d49f0b2440513e5ee091d838b/module-options.nix#L116-L135

Fixes #308