### PR TITLE
feat: improve unmatched logic

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -3,11 +3,12 @@ package cli
 import (
 	"os"
 
+	"github.com/gobwas/glob"
+
 	"git.numtide.com/numtide/treefmt/format"
 	"git.numtide.com/numtide/treefmt/walk"
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/log"
-	"github.com/gobwas/glob"
 )
 
 func New() *Format {
@@ -36,8 +37,8 @@ type Format struct {
 
 	CpuProfile string `optional:"" help:"The file into which a cpu profile will be written."`
 
-	excludes   []glob.Glob
-	formatters map[string]*format.Formatter
+	formatters     map[string]*format.Formatter
+	globalExcludes []glob.Glob
 
 	filesCh     chan *walk.File
 	processedCh chan *walk.File

--- a/cli/format_test.go
+++ b/cli/format_test.go
@@ -39,21 +39,22 @@ func TestOnUnmatched(t *testing.T) {
 	paths := []string{
 		"go/go.mod",
 		"haskell/haskell.cabal",
-		"haskell/treefmt.toml",
 		"html/scripts/.gitkeep",
-		"nixpkgs.toml",
 		"python/requirements.txt",
-		"rust/Cargo.toml",
-		"touch.toml",
-		"treefmt.toml",
+		// these should not be reported as they're in the global excludes
+		// - "nixpkgs.toml"
+		// - "touch.toml"
+		// - "treefmt.toml"
+		// - "rust/Cargo.toml"
+		// - "haskell/treefmt.toml"
 	}
 
 	out, err := cmd(t, "-C", tempDir, "--allow-missing-formatter", "--on-unmatched", "fatal")
-	as.ErrorContains(err, fmt.Sprintf("no formatter for path: %s/%s", tempDir, paths[0]))
+	as.ErrorContains(err, fmt.Sprintf("no formatter for path: %s", paths[0]))
 
 	checkOutput := func(level string, output []byte) {
 		for _, p := range paths {
-			as.Contains(string(output), fmt.Sprintf("%s format: no formatter for path: %s/%s", level, tempDir, p))
+			as.Contains(string(output), fmt.Sprintf("%s format: no formatter for path: %s", level, p))
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,6 +14,8 @@ func TestReadConfigFile(t *testing.T) {
 
 	as.NotNil(cfg)
 
+	as.Equal([]string{"*.toml"}, cfg.Global.Excludes)
+
 	// python
 	python, ok := cfg.Formatters["python"]
 	as.True(ok, "python formatter not found")

--- a/format/formatter.go
+++ b/format/formatter.go
@@ -100,7 +100,6 @@ func NewFormatter(
 	name string,
 	treeRoot string,
 	cfg *config.Formatter,
-	globalExcludes []glob.Glob,
 ) (*Formatter, error) {
 	var err error
 
@@ -136,7 +135,6 @@ func NewFormatter(
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile formatter '%v' excludes: %w", f.name, err)
 	}
-	f.excludes = append(f.excludes, globalExcludes...)
 
 	return &f, nil
 }

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -22,33 +22,32 @@
         statix.enable = true;
       };
 
-      settings.formatter = {
-        deadnix = {
-          priority = 1;
-        };
+      settings = {
+        global.excludes = [
+          "LICENSE"
+          # let's not mess with the test folder
+          "test/**"
+          # unsupported extensions
+          "*.{gif,png,svg,tape,mts,lock,mod,sum,toml,env,envrc,gitignore}"
+        ];
 
-        statix = {
-          priority = 2;
-        };
+        formatter = {
+          deadnix = {
+            priority = 1;
+          };
 
-        alejandra = {
-          priority = 3;
-        };
+          statix = {
+            priority = 2;
+          };
 
-        prettier = {
-          options = ["--tab-width" "4"];
-          includes = [
-            "*.css"
-            "*.html"
-            "*.js"
-            "*.json"
-            "*.jsx"
-            "*.md"
-            "*.mdx"
-            "*.scss"
-            "*.ts"
-            "*.yaml"
-          ];
+          alejandra = {
+            priority = 3;
+          };
+
+          prettier = {
+            options = ["--tab-width" "4"];
+            includes = ["*.{css,html,js,json,jsx,md,mdx,scss,ts,yaml}"];
+          };
         };
       };
     };

--- a/test/examples/treefmt.toml
+++ b/test/examples/treefmt.toml
@@ -1,5 +1,8 @@
 # One CLI to format the code tree - https://git.numtide.com/numtide/treefmt
 
+[global]
+excludes = ["*.toml"]
+
 [formatter.python]
 command = "black"
 includes = ["*.py"]


### PR DESCRIPTION
Separates global excludes processing from `Formatter.Wants`. This removes redundant processing of global excludes in each `Formatter.Wants` call.

If a file has been globally excluded, we do not emit an `on-unmatched` log message. This should help reduce noise as reported in #317.

Signed-off-by: Brian McGee <brian@bmcgee.ie>
