### PR TITLE
chore: do a golangci-lint pass

### DIFF
--- a/cli/format_test.go
+++ b/cli/format_test.go
@@ -49,7 +49,7 @@ func TestOnUnmatched(t *testing.T) {
 		// - "haskell/treefmt.toml"
 	}
 
-	out, err := cmd(t, "-C", tempDir, "--allow-missing-formatter", "--on-unmatched", "fatal")
+	_, err = cmd(t, "-C", tempDir, "--allow-missing-formatter", "--on-unmatched", "fatal")
 	as.ErrorContains(err, fmt.Sprintf("no formatter for path: %s", paths[0]))
 
 	checkOutput := func(level string, output []byte) {
@@ -57,6 +57,8 @@ func TestOnUnmatched(t *testing.T) {
 			as.Contains(string(output), fmt.Sprintf("%s format: no formatter for path: %s", level, p))
 		}
 	}
+
+	var out []byte
 
 	// default is warn
 	out, err = cmd(t, "-C", tempDir, "--allow-missing-formatter", "-c")
@@ -271,8 +273,13 @@ func TestCache(t *testing.T) {
 		},
 	}
 
+	var (
+		out []byte
+		err error
+	)
+
 	test.WriteConfig(t, configPath, cfg)
-	out, err := cmd(t, "--config-file", configPath, "--tree-root", tempDir)
+	_, err = cmd(t, "--config-file", configPath, "--tree-root", tempDir)
 	as.NoError(err)
 	assertStats(t, as, 31, 31, 31, 0)
 
@@ -281,7 +288,7 @@ func TestCache(t *testing.T) {
 	assertFormatted(t, as, out, 0)
 
 	// clear cache
-	out, err = cmd(t, "--config-file", configPath, "--tree-root", tempDir, "-c")
+	_, err = cmd(t, "--config-file", configPath, "--tree-root", tempDir, "-c")
 	as.NoError(err)
 	assertStats(t, as, 31, 31, 31, 0)
 
@@ -290,7 +297,7 @@ func TestCache(t *testing.T) {
 	assertFormatted(t, as, out, 0)
 
 	// clear cache
-	out, err = cmd(t, "--config-file", configPath, "--tree-root", tempDir, "-c")
+	_, err = cmd(t, "--config-file", configPath, "--tree-root", tempDir, "-c")
 	as.NoError(err)
 	assertStats(t, as, 31, 31, 31, 0)
 
@@ -299,7 +306,7 @@ func TestCache(t *testing.T) {
 	assertFormatted(t, as, out, 0)
 
 	// no cache
-	out, err = cmd(t, "--config-file", configPath, "--tree-root", tempDir, "--no-cache")
+	_, err = cmd(t, "--config-file", configPath, "--tree-root", tempDir, "--no-cache")
 	as.NoError(err)
 	assertStats(t, as, 31, 31, 31, 0)
 }

--- a/format/formatter.go
+++ b/format/formatter.go
@@ -31,8 +31,6 @@ type Formatter struct {
 	// internal compiled versions of Includes and Excludes.
 	includes []glob.Glob
 	excludes []glob.Glob
-
-	batch []string
 }
 
 // Executable returns the path to the executable defined by Command
@@ -80,7 +78,7 @@ func (f *Formatter) Apply(ctx context.Context, tasks []*Task) error {
 
 	//
 
-	f.log.Infof("%v files processed in %v", len(tasks), time.Now().Sub(start))
+	f.log.Infof("%v files processed in %v", len(tasks), time.Since(start))
 
 	return nil
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -28,6 +28,7 @@
           # golang
           go
           goreleaser
+          golangci-lint
           delve
           pprof
           graphviz

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -42,7 +42,7 @@ func Value(t Type) int32 {
 }
 
 func Elapsed() time.Duration {
-	return time.Now().Sub(start)
+	return time.Since(start)
 }
 
 func Print() {

--- a/walk/filesystem.go
+++ b/walk/filesystem.go
@@ -28,7 +28,7 @@ func (f filesystemWalker) Walk(_ context.Context, fn WalkFunc) error {
 		return filepath.Rel(f.root, path)
 	}
 
-	walkFn := func(path string, info fs.FileInfo, err error) error {
+	walkFn := func(path string, info fs.FileInfo, _ error) error {
 		if info == nil {
 			return fmt.Errorf("no such file or directory '%s'", path)
 		}

--- a/walk/git.go
+++ b/walk/git.go
@@ -88,7 +88,7 @@ func (g *gitWalker) Walk(ctx context.Context, fn WalkFunc) error {
 			continue
 		}
 
-		return filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		return filepath.Walk(path, func(path string, info fs.FileInfo, _ error) error {
 			if info.IsDir() {
 				return nil
 			}


### PR DESCRIPTION
golangci-lint doesn't follow the treefmt spec so it can't be integrated
with treefmt unfortunately.