### PR TITLE
Softer cancel

### DIFF
--- a/cli/format.go
+++ b/cli/format.go
@@ -325,9 +325,11 @@ func (f *Format) walkFilesystem(ctx context.Context) func() error {
 	}
 }
 
+// applyFormatters
 func (f *Format) applyFormatters(ctx context.Context) func() error {
-	// create our own errgroup for concurrent formatting tasks
-	fg, ctx := errgroup.WithContext(ctx)
+	// create our own errgroup for concurrent formatting tasks.
+	// we don't want a cancel clause, in order to let formatters run up to the end.
+	fg := errgroup.Group{}
 	// simple optimization to avoid too many concurrent formatting tasks
 	// we can queue them up faster than the formatters can process them, this paces things a bit
 	fg.SetLimit(runtime.NumCPU())

--- a/format/formatter.go
+++ b/format/formatter.go
@@ -66,6 +66,10 @@ func (f *Formatter) Apply(ctx context.Context, tasks []*Task) error {
 
 	// execute the command
 	cmd := exec.CommandContext(ctx, f.executable, args...)
+	// replace the default Cancel handler installed by CommandContext because it sends SIGKILL (-9).
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(os.Interrupt)
+	}
 	cmd.Dir = f.workingDir
 
 	// log out the command being executed


### PR DESCRIPTION
Tune the error handling to fail more gracefully. And restore similar behaviour to treefmt 1.x

Fixes #316