### PR TITLE
docs: adds information regarding IDE integration in vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,17 @@ For instance, you can go for:
 
 Find the full list of supported formatters [here](https://treefmt.com/configure.html#supported-formatters).
 
+## IDE Integration
+
+`treefmt` currently has support for vscode via an extension:
+
+-   [treefmt-vscode](https://marketplace.visualstudio.com/items?itemName=ibecker.treefmt-vscode) | [GitHub repo](https://github.com/isbecker/treefmt-vscode)
+
 ## Upcoming features
 
 This project is still pretty new. Down the line we also want to add support for:
 
--   IDE integration
+-   More IDE integration
 -   Pre-commit hooks
 
 ## Related projects


### PR DESCRIPTION
This PR makes a small change to the docs to include a mention to a [vscode extension](https://marketplace.visualstudio.com/items?itemName=ibecker.treefmt-vscode) that I wrote.

- added section `IDE integration`
  - mentions [treefmt-vscode](https://github.com/isbecker/treefmt-vscode)
- changes `Upcoming features` on IDEs to "More IDE integration", now reflecting that there is some IDE integration