### PR TITLE
doc: fix global excludes config example

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -7,6 +7,7 @@ outline: deep
 The `treefmt.toml` configuration file consists of a mixture of global options and formatter sections:
 
 ```toml
+[global]
 excludes = ["*.md", "*.dat"]
 
 [formatter.elm]


### PR DESCRIPTION
Fixes config example showing how to configure global excludes properly. 

Signed-off-by: Brian McGee <brian@bmcgee.ie>
