### PR TITLE
Improve summary stats

### DIFF
--- a/cli/helpers_test.go
+++ b/cli/helpers_test.go
@@ -86,5 +86,5 @@ func assertStats(t *testing.T, as *require.Assertions, traversed int32, emitted 
 
 func assertFormatted(t *testing.T, as *require.Assertions, output []byte, count int) {
 	t.Helper()
-	as.Contains(string(output), fmt.Sprintf("formatted %d files", count))
+	as.Contains(string(output), fmt.Sprintf("(%d changed)", count))
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -26,8 +26,6 @@ versions.forEach(version => {
   sidebar[`/${version}/`] = sidebar["/"].map(({ text, link }) => ({ text, link: `/${version}${link}`}))
 })
 
-console.log("sidebar", sidebar)
-
 // https://vitepress.dev/reference/site-config
 export default defineVersionedConfig({
   base: '/',

--- a/docs/about.md
+++ b/docs/about.md
@@ -46,20 +46,18 @@ instance, take the caching optimization.
 
 It takes about 23 seconds to traverse a project of 40,559 files and no changes without caching:
 
-```
+```console
 traversed 41273 files
 emitted 41273 files for processing
-matched 34311 files to formatters
-formatted 14338 files in 23.679339987s
+formatted 34111 files (14338 changed) in 23.679s
 ```
 
 ...while it takes **239 milliseconds** to traverse the same project with caching:
 
-```
+```console
 traversed 41273 files
 emitted 0 files for processing
-matched 0 files to formatters
-formatted 0 files in 239.024064ms
+formatted 0 files (0 changed) in 239ms
 ```
 
 The tool can be invoked manually or integrated into your CI. There's currently no integration with IDEs, but the feature is coming soon.

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -49,8 +49,7 @@ func Print() {
 	components := []string{
 		"traversed %d files",
 		"emitted %d files for processing",
-		"matched %d files to formatters",
-		"formatted %d files in %v",
+		"formatted %d files (%d changed) in %v",
 		"",
 	}
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -60,6 +60,6 @@ func Print() {
 		Value(Emitted),
 		Value(Matched),
 		Value(Formatted),
-		Elapsed(),
+		Elapsed().Round(time.Millisecond),
 	)
 }


### PR DESCRIPTION
Rounds elapsed time to nearest millisecond and changes stats phrasing to make it clearer.

```console
❯ nix fmt -- -c 
traversed 97 files
emitted 97 files for processing
formatted 49 files (0 changed) in 551ms
```

Close #337
Close #339 

## TODO
- [x] update docs after https://github.com/numtide/treefmt/pull/341

Signed-off-by: Brian McGee <brian@bmcgee.ie>
