### PR TITLE
feat: search for .treefmt.toml

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -20,7 +20,7 @@ type Format struct {
 	WorkingDirectory      kong.ChangeDirFlag `default:"." short:"C" help:"Run as if treefmt was started in the specified working directory instead of the current working directory."`
 	NoCache               bool               `help:"Ignore the evaluation cache entirely. Useful for CI."`
 	ClearCache            bool               `short:"c" help:"Reset the evaluation cache. Use in case the cache is not precise enough."`
-	ConfigFile            string             `type:"existingfile" help:"Load the config file from the given path (defaults to searching upwards for treefmt.toml)."`
+	ConfigFile            string             `type:"existingfile" help:"Load the config file from the given path (defaults to searching upwards for treefmt.toml or .treefmt.toml)."`
 	FailOnChange          bool               `help:"Exit with error if any changes were made. Useful for CI."`
 	Formatters            []string           `short:"f" help:"Specify formatters to apply. Defaults to all formatters."`
 	TreeRoot              string             `type:"existingdir" xor:"tree-root" env:"PRJ_ROOT" help:"The root directory from which treefmt will start walking the filesystem (defaults to the directory containing the config file)."`

--- a/cli/format.go
+++ b/cli/format.go
@@ -66,7 +66,7 @@ func (f *Format) Run() (err error) {
 		if err != nil {
 			return err
 		}
-		f.ConfigFile, _, err = findUp(pwd, "treefmt.toml")
+		f.ConfigFile, _, err = findUp(pwd, "treefmt.toml", ".treefmt.toml")
 		if err != nil {
 			return err
 		}
@@ -496,14 +496,16 @@ func (f *Format) updateCache(ctx context.Context) func() error {
 	}
 }
 
-func findUp(searchDir string, fileName string) (path string, dir string, err error) {
+func findUp(searchDir string, fileNames ...string) (path string, dir string, err error) {
 	for _, dir := range eachDir(searchDir) {
-		path := filepath.Join(dir, fileName)
-		if fileExists(path) {
-			return path, dir, nil
+		for _, f := range fileNames {
+			path := filepath.Join(dir, f)
+			if fileExists(path) {
+				return path, dir, nil
+			}
 		}
 	}
-	return "", "", fmt.Errorf("could not find %s in %s", fileName, searchDir)
+	return "", "", fmt.Errorf("could not find %s in %s", fileNames, searchDir)
 }
 
 func eachDir(path string) (paths []string) {


### PR DESCRIPTION
This restores treefmt v1 compatibility by also searching for the dot prefixed version of the config file.

Fixes #355