### PR TITLE
apply all formatters even when there's errors

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -43,8 +43,8 @@ type Format struct {
 	globalExcludes []glob.Glob
 
 	filesCh     chan *walk.File
-	formattedCh chan *walk.File
-	processedCh chan *walk.File
+	formattedCh chan *format.Task
+	processedCh chan *format.Task
 }
 
 func (f *Format) configureLogging() {

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,8 +37,6 @@ updated `nix/packages/treefmt/gomod2nix.toml`.
 
 To sync it up, run `nix develop .#renovate -c gomod2nix:update`.
 
-
-
 ## Making changes
 
 If you want to introduce changes to the project, please follow these steps:

--- a/format/formatter.go
+++ b/format/formatter.go
@@ -75,15 +75,14 @@ func (f *Formatter) Apply(ctx context.Context, tasks []*Task) error {
 	f.log.Debugf("executing: %s", cmd.String())
 
 	if out, err := cmd.CombinedOutput(); err != nil {
+		f.log.Errorf("failed to apply with options '%v': %s", f.config.Options, err)
 		if len(out) > 0 {
 			_, _ = fmt.Fprintf(os.Stderr, "%s error:\n%s\n", f.name, out)
 		}
 		return fmt.Errorf("formatter '%s' with options '%v' failed to apply: %w", f.config.Command, f.config.Options, err)
+	} else {
+		f.log.Infof("%v file(s) processed in %v", len(tasks), time.Since(start))
 	}
-
-	//
-
-	f.log.Infof("%v file(s) processed in %v", len(tasks), time.Since(start))
 
 	return nil
 }

--- a/format/task.go
+++ b/format/task.go
@@ -11,6 +11,7 @@ type Task struct {
 	File       *walk.File
 	Formatters []*Formatter
 	BatchKey   string
+	Errors     []error
 }
 
 func NewTask(file *walk.File, formatters []*Formatter) Task {


### PR DESCRIPTION
When applying a sequence of formatters, continue applying the batch to successive formatters even if one of the stages fails. 

Closes #316 
