### PR TITLE
CI flag

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -37,6 +37,8 @@ type Format struct {
 
 	CpuProfile string `optional:"" help:"The file into which a cpu profile will be written."`
 
+	Ci bool `help:"Runs treefmt in a CI mode, enabling --no-cache, --fail-on-change and adjusting some other settings best suited to a CI use case."`
+
 	formatters     map[string]*format.Formatter
 	globalExcludes []glob.Glob
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,6 +31,7 @@ Flags:
                                      <debug|info|warn|error|fatal>.
       --stdin                        Format the context passed in via stdin.
       --cpu-profile=STRING           The file into which a cpu profile will be written.
+      --ci                           Runs treefmt in a CI mode, enabling --no-cache, --fail-on-change and adjusting some other settings best suited to a CI use case.
 ```
 
 ## Arguments
@@ -112,13 +113,22 @@ Format the context passed in via stdin.
 
 The file into which a cpu profile will be written.
 
+### `--ci`
+
+Runs treefmt in a CI mode which does the following:
+
+-   ensures `INFO` level logging at a minimum
+-   enables `--no-cache` and `--fail-on-change`
+-   introduces a small startup delay so we do not start processing until the second after the process started, thereby
+    ensuring the accuracy of our change detection based on second-level `modtime`.
+
 ### `-V, --version`
 
 Print version.
 
 ## CI integration
 
-Typically, you would use `treefmt` in CI with the `--fail-on-change` and `--no-cache flags`.
+Typically, you would use `treefmt` in CI with the `--ci` flag.
 
 You can configure a `treefmt` job in a GitHub pipeline for Ubuntu with `nix-shell` like this:
 
@@ -141,5 +151,5 @@ jobs:
                   name: nix-community
                   authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
             - name: treefmt
-              run: nix-shell -p treefmt --run "treefmt --fail-on-change --no-cache"
+              run: nix-shell -p treefmt --run "treefmt --ci"
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -75,12 +75,27 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gomod2nix": {
       "inputs": {
-        "flake-utils": [
-          "devshell",
-          "flake-utils"
-        ],
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -171,6 +186,21 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -178,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719887753,
-        "narHash": "sha256-p0B2r98UtZzRDM5miGRafL4h7TwGRC4DII+XXHDHqek=",
+        "lastModified": 1722330636,
+        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "bdb6355009562d8f9313d9460c0d3860f525bc6c",
+        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,6 @@
     gomod2nix = {
       url = "github:nix-community/gomod2nix";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "devshell/flake-utils";
     };
     flake-compat.url = "github:nix-community/flake-compat";
     nix-filter.url = "github:numtide/nix-filter";

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -30,6 +30,16 @@ perSystem.devshell.mkShell {
 
   commands = [
     {package = perSystem.gomod2nix.default;}
+    # This custom command is needed to prevent a conflict between --tree-root and --tree-root-file.
+    # treefmt-nix sets --tree-root-file whilst treefmt defaults --tree-root from $PRJ_ROOT, which is set by numtide/devshell.
+    {
+      name = "fmt";
+      help = "runs `nix fmt` but unsets $PRJ_ROOT first";
+      package = pkgs.writeShellScriptBin "fmt" ''
+        unset PRJ_ROOT
+        nix fmt -- "$@"
+      '';
+    }
     {
       name = "docs:dev";
       help = "serve docs for local development";

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended"]
 }


### PR DESCRIPTION
Adds a `--ci` flag which does the following:

- ensures `INFO` level logging at a minimum
- `--no-cache`
- `--fail-on-change`

This also adds a delay on startup which is intended to ensure we do not start doing anything until we have moved into the second after the one in which the process started. This helps to ensure accurate comparisons of `modtime` using truncated second-level precision for change detection.

This is only an issue in scenarios in which treefmt is being executed quickly in succession or directly after an automatic checkout, such as in CI.

Closes #365 
Related to some behaviour reported in #316 

Signed-off-by: Brian McGee <brian@bmcgee.ie>