### PR TITLE
Avoid hanging: ensure we always close `f.filesCh`

### DIFF
--- a/cli/format.go
+++ b/cli/format.go
@@ -201,6 +201,9 @@ func (f *Format) Run() (err error) {
 
 func (f *Format) walkFilesystem(ctx context.Context) func() error {
 	return func() error {
+		// close the files channel when we're done walking the file system
+		defer close(f.filesCh)
+
 		eg, ctx := errgroup.WithContext(ctx)
 		pathsCh := make(chan string, BatchSize)
 
@@ -260,9 +263,6 @@ func (f *Format) walkFilesystem(ctx context.Context) func() error {
 		if err != nil {
 			return fmt.Errorf("failed to create walker: %w", err)
 		}
-
-		// close the files channel when we're done walking the file system
-		defer close(f.filesCh)
 
 		// if no cache has been configured, or we are processing from stdin, we invoke the walker directly
 		if f.NoCache || f.Stdin {

--- a/cli/format.go
+++ b/cli/format.go
@@ -216,7 +216,7 @@ func (f *Format) walkFilesystem(ctx context.Context) func() error {
 
 			// check we have only received one path arg which we use for the file extension / matching to formatters
 			if len(f.Paths) != 1 {
-				return fmt.Errorf("only one path should be specified when using the --stdin flag")
+				return fmt.Errorf("exactly one path should be specified when using the --stdin flag")
 			}
 
 			// read stdin into a temporary file with the same file extension

--- a/cli/format_test.go
+++ b/cli/format_test.go
@@ -604,11 +604,19 @@ func TestStdIn(t *testing.T) {
 		os.Stdin = prevStdIn
 	})
 
-	//
+	// omit the required filename parameter
 	contents := `{ foo, ... }: "hello"`
 	os.Stdin = test.TempFile(t, "", "stdin", &contents)
+	// we get an error about the missing filename parameter.
+	out, err := cmd(t, "-C", tempDir, "--allow-missing-formatter", "--stdin")
+	as.EqualError(err, "only one path should be specified when using the --stdin flag")
+	as.Equal("", string(out))
 
-	out, err := cmd(t, "-C", tempDir, "--allow-missing-formatter", "--stdin", "test.nix")
+	// now pass along the filename parameter
+	contents = `{ foo, ... }: "hello"`
+	os.Stdin = test.TempFile(t, "", "stdin", &contents)
+
+	out, err = cmd(t, "-C", tempDir, "--allow-missing-formatter", "--stdin", "test.nix")
 	as.NoError(err)
 	assertStats(t, as, 1, 1, 1, 1)
 

--- a/cli/format_test.go
+++ b/cli/format_test.go
@@ -609,7 +609,7 @@ func TestStdIn(t *testing.T) {
 	os.Stdin = test.TempFile(t, "", "stdin", &contents)
 	// we get an error about the missing filename parameter.
 	out, err := cmd(t, "-C", tempDir, "--allow-missing-formatter", "--stdin")
-	as.EqualError(err, "only one path should be specified when using the --stdin flag")
+	as.EqualError(err, "exactly one path should be specified when using the --stdin flag")
 	as.Equal("", string(out))
 
 	// now pass along the filename parameter


### PR DESCRIPTION
The contract seems to be that the `walkFilesystem` goroutine is
responsible for closing `f.filesCh`, but before this change, there were
codepaths that could result in the gorouting exiting without closing
`f.filesCh`. That shouldn't be possible anymore, so long as we keep this
statement at the top of the function =)

This fixes https://github.com/numtide/treefmt/issues/406
