### PR TITLE
Clarify in the spec that the formatter MUST process the given files

### DIFF
--- a/docs/formatter-spec.md
+++ b/docs/formatter-spec.md
@@ -38,6 +38,8 @@ $ rustfmt --edition 2018 src/main.rs src/lib.rs
 ```
 
 > [!IMPORTANT]
+> It _MUST_ process the specified files. For example, it _MUST_ NOT ignore files because they are not tracked by a VCS.
+>
 > It _SHOULD_ processes only the specified files. Files that are not passed _SHOULD_ never be formatted.
 
 ### 2. Write to changed files


### PR DESCRIPTION
Some formatters are aware of VCS systems like git, and "helpfully" skip over files that are not tracked by the VCS system. This doesn't play nicely with treefmt, because treefmt expects to be able to generate tempfiles (which are not tracked by a VCS) and pass them to the formatter.