### PR TITLE
Improve path argument handling

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
             - name: golangci-lint
               uses: golangci/golangci-lint-action@v6
               with:
-                  version: v1.59.1
+                  version: v1.61.0
                   args: --timeout=2m

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -628,11 +628,11 @@ func TestGitWorktree(t *testing.T) {
 
 	_, statz, err = treefmt(t, "-C", tempDir, "-c", "haskell", "foo.txt")
 	as.NoError(err)
-	assertStats(t, as, statz, 7, 7, 7, 0)
+	assertStats(t, as, statz, 8, 8, 8, 0)
 
 	_, statz, err = treefmt(t, "-C", tempDir, "-c", "foo.txt")
 	as.NoError(err)
-	assertStats(t, as, statz, 0, 0, 0, 0)
+	assertStats(t, as, statz, 1, 1, 1, 0)
 }
 
 func TestPathsArg(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/numtide/treefmt/walk"
+
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -173,6 +175,11 @@ func FromViper(v *viper.Viper) (*Config, error) {
 	cfg.WorkingDirectory, err = filepath.Abs(cfg.WorkingDirectory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get absolute path for working directory: %w", err)
+	}
+
+	// if the stdin flag was passed, we force the stdin walk type
+	if cfg.Stdin {
+		cfg.Walk = walk.Stdin.String()
 	}
 
 	// determine the tree root

--- a/walk/cached.go
+++ b/walk/cached.go
@@ -95,9 +95,10 @@ func (c *CachedReader) Read(ctx context.Context, files []*File) (n int, err erro
 			}
 
 			// set a release function which inserts this file into the release channel for updating
-			file.Release = func() {
+			file.AddReleaseFunc(func() error {
 				c.releaseCh <- file
-			}
+				return nil
+			})
 		}
 
 		if errors.Is(err, io.EOF) {

--- a/walk/filesystem_test.go
+++ b/walk/filesystem_test.go
@@ -56,7 +56,7 @@ func TestFilesystemReader(t *testing.T) {
 	tempDir := test.TempExamples(t)
 	statz := stats.New()
 
-	r := walk.NewFilesystemReader(tempDir, nil, &statz, 1024)
+	r := walk.NewFilesystemReader(tempDir, "", &statz, 1024)
 
 	count := 0
 

--- a/walk/git_test.go
+++ b/walk/git_test.go
@@ -40,7 +40,7 @@ func TestGitReader(t *testing.T) {
 
 	statz := stats.New()
 
-	reader, err := walk.NewGitReader(tempDir, nil, &statz, 1024)
+	reader, err := walk.NewGitReader(tempDir, "", &statz, 1024)
 	as.NoError(err)
 
 	count := 0

--- a/walk/stdin.go
+++ b/walk/stdin.go
@@ -1,0 +1,97 @@
+package walk
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/numtide/treefmt/stats"
+)
+
+type StdinReader struct {
+	root  string
+	path  string
+	stats stats.Stats
+	input *os.File
+
+	complete bool
+}
+
+func (s StdinReader) Read(_ context.Context, files []*File) (n int, err error) {
+	if s.complete {
+		return 0, io.EOF
+	}
+
+	// read stdin into a temporary file with the same file extension
+	pattern := fmt.Sprintf("*%s", filepath.Ext(s.path))
+
+	file, err := os.CreateTemp(s.root, pattern)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create a temporary file for processing stdin: %w", err)
+	}
+	defer file.Close()
+
+	if _, err = io.Copy(file, s.input); err != nil {
+		return 0, fmt.Errorf("failed to copy stdin into a temporary file")
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get file info for temporary file: %w", err)
+	}
+
+	relPath, err := filepath.Rel(s.root, file.Name())
+	if err != nil {
+		return 0, fmt.Errorf("failed to get relative path for temporary file: %w", err)
+	}
+
+	files[0] = &File{
+		Path:    file.Name(),
+		RelPath: relPath,
+		Info:    info,
+	}
+
+	// dump the temp file to stdout and remove it once the file is finished being processed
+	files[0].AddReleaseFunc(func() error {
+		// open the temp file
+		file, err := os.Open(file.Name())
+		if err != nil {
+			return fmt.Errorf("failed to open temp file %s: %w", file.Name(), err)
+		}
+
+		// dump file into stdout
+		if _, err = io.Copy(os.Stdout, file); err != nil {
+			return fmt.Errorf("failed to copy %s to stdout: %w", file.Name(), err)
+		}
+
+		if err = file.Close(); err != nil {
+			return fmt.Errorf("failed to close temp file %s: %w", file.Name(), err)
+		}
+
+		if err = os.Remove(file.Name()); err != nil {
+			return fmt.Errorf("failed to remove temp file %s: %w", file.Name(), err)
+		}
+
+		return nil
+	})
+
+	s.complete = true
+	s.stats.Add(stats.Traversed, 1)
+
+	return 1, io.EOF
+}
+
+func (s StdinReader) Close() error {
+	return nil
+}
+
+func NewStdinReader(root string, path string, statz *stats.Stats) Reader {
+	return StdinReader{
+		root:  root,
+		path:  path,
+		stats: *statz,
+		input: os.Stdin,
+	}
+}

--- a/walk/type_enum.go
+++ b/walk/type_enum.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _TypeName = "autogitfilesystem"
+const _TypeName = "autogitfilesystemstdin"
 
-var _TypeIndex = [...]uint8{0, 4, 7, 17}
+var _TypeIndex = [...]uint8{0, 4, 7, 17, 22}
 
-const _TypeLowerName = "autogitfilesystem"
+const _TypeLowerName = "autogitfilesystemstdin"
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_TypeIndex)-1) {
@@ -27,23 +27,27 @@ func _TypeNoOp() {
 	_ = x[Auto-(0)]
 	_ = x[Git-(1)]
 	_ = x[Filesystem-(2)]
+	_ = x[Stdin-(3)]
 }
 
-var _TypeValues = []Type{Auto, Git, Filesystem}
+var _TypeValues = []Type{Auto, Git, Filesystem, Stdin}
 
 var _TypeNameToValueMap = map[string]Type{
-	_TypeName[0:4]:       Auto,
-	_TypeLowerName[0:4]:  Auto,
-	_TypeName[4:7]:       Git,
-	_TypeLowerName[4:7]:  Git,
-	_TypeName[7:17]:      Filesystem,
-	_TypeLowerName[7:17]: Filesystem,
+	_TypeName[0:4]:        Auto,
+	_TypeLowerName[0:4]:   Auto,
+	_TypeName[4:7]:        Git,
+	_TypeLowerName[4:7]:   Git,
+	_TypeName[7:17]:       Filesystem,
+	_TypeLowerName[7:17]:  Filesystem,
+	_TypeName[17:22]:      Stdin,
+	_TypeLowerName[17:22]: Stdin,
 }
 
 var _TypeNames = []string{
 	_TypeName[0:4],
 	_TypeName[4:7],
 	_TypeName[7:17],
+	_TypeName[17:22],
 }
 
 // TypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
Changes how we handle paths which are provided as arguments:

- if it's a file, we attempt to format it based on the matching options
- if it's a directory, we traverse it using the provided walk type

This is more consistent with what a user expects and makes it easier to integrate with tools such as `none-ls`.

Close #435