### PR TITLE
fix: correct handling of absolute and relative paths

### DIFF
--- a/test/temp.go
+++ b/test/temp.go
@@ -27,13 +27,16 @@ func WriteConfig(t *testing.T, path string, cfg *config.Config) {
 
 func TempExamples(t *testing.T) string {
 	tempDir := t.TempDir()
-	require.NoError(t, cp.Copy("../test/examples", tempDir), "failed to copy test data to temp dir")
+	TempExamplesInDir(t, tempDir)
+	return tempDir
+}
+
+func TempExamplesInDir(t *testing.T, dir string) {
+	require.NoError(t, cp.Copy("../test/examples", dir), "failed to copy test data to dir")
 
 	// we have second precision mod time tracking, so we wait a second before returning, so we don't trigger false
 	//positives for things like fail on change
 	time.Sleep(time.Second)
-
-	return tempDir
 }
 
 func TempFile(t *testing.T, dir string, pattern string, contents *string) *os.File {


### PR DESCRIPTION
This fixes a few issues with both relative and absolute paths:

- Previously, treefmt refused to format any files passed as absolute paths, regardless of if they were in tree or not: https://github.com/numtide/treefmt/issues/442
- Previously, treefmt would treat relative paths as relative to the project root, which is not ideal if you're in a subdirectory and you just want to format the file you're right next to: https://github.com/numtide/treefmt/issues/443
  - There was even a test asserting this behavior. I changed it to reflect the updated behavior.
- treefmt's handling of paths outside of the project root was a bit inconsistent: https://github.com/numtide/treefmt/issues/444