### PR TITLE
fix: normalize and enforce stdin paths as well

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -748,6 +748,14 @@ func TestStdin(t *testing.T) {
 	as.Equal(`{ ...}: "hello"
 `, string(out))
 
+	// try a file that's outside of the project root
+	contents = `{ foo, ... }: "hello"`
+	os.Stdin = test.TempFile(t, "", "stdin", &contents)
+
+	out, _, err = treefmt(t, "-C", tempDir, "--allow-missing-formatter", "--stdin", "../test.nix")
+	as.Errorf(err, "path ../test.nix not inside the tree root %s", tempDir)
+	as.Equal("", string(out))
+
 	// try some markdown instead
 	contents = `
 | col1 | col2 |


### PR DESCRIPTION
See https://github.com/numtide/treefmt/pull/440 for the last attempt to
do this because (at the time) this "is the file in the tree root?" check
relied upon checking for concrete files in the filesystem. As of
https://github.com/numtide/treefmt/commit/ff3de21a2b35a3218e845609ccd5a6a7215e9fdc,
that's longer the case, so we can make this code a bit more consistent.
