### PR TITLE
better error if command cannot be found

### DIFF
--- a/format/formatter.go
+++ b/format/formatter.go
@@ -155,7 +155,7 @@ func newFormatter(
 	// test if the formatter is available
 	executable, err := interp.LookPathDir(treeRoot, env, cfg.Command)
 	if err != nil {
-		return nil, ErrCommandNotFound
+		return nil, fmt.Errorf("%w: error looking up '%s'", ErrCommandNotFound, cfg.Command)
 	}
 
 	f.executable = executable


### PR DESCRIPTION
In this case the command was empty:

```
       > Error: failed to create composite formatter: failed to initialise formatter mypy-: formatter command not found in PATH
```

