### PR TITLE
Verbosity changes

### DIFF
--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -197,9 +197,9 @@ func Run(v *viper.Viper, statz *stats.Stats, cmd *cobra.Command, paths []string)
 		return fmt.Errorf("failed to close walker: %w", err)
 	}
 
-	// print stats to stdout, unless we are processing from stdin and therefore outputting the results to stdout
-	if !cfg.Stdin {
-		statz.Print()
+	// print stats to stderr
+	if !cfg.Quiet {
+		statz.PrintToStderr()
 	}
 
 	if formatErr != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,7 +131,7 @@ func runE(v *viper.Viper, statz *stats.Stats, cmd *cobra.Command, args []string)
 		return fmt.Errorf("failed to find treefmt config file: %w", err)
 	}
 
-	log.Infof("using config file: %s", configFile)
+	log.Debugf("using config file: %s", configFile)
 
 	// read in the config
 	v.SetConfigFile(configFile)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,13 +144,19 @@ func runE(v *viper.Viper, statz *stats.Stats, cmd *cobra.Command, args []string)
 	log.SetOutput(os.Stderr)
 	log.SetReportTimestamp(false)
 
-	switch v.GetInt("verbose") {
-	case 0:
-		log.SetLevel(log.WarnLevel)
-	case 1:
-		log.SetLevel(log.InfoLevel)
-	default:
-		log.SetLevel(log.DebugLevel)
+	if v.GetBool("quiet") {
+		// if quiet, we only log errors
+		log.SetLevel(log.ErrorLevel)
+	} else {
+		// otherwise, the verbose flag controls the log level
+		switch v.GetInt("verbose") {
+		case 0:
+			log.SetLevel(log.WarnLevel)
+		case 1:
+			log.SetLevel(log.InfoLevel)
+		default:
+			log.SetLevel(log.DebugLevel)
+		}
 	}
 
 	// format

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -72,9 +72,9 @@ func TestOnUnmatched(t *testing.T) {
 		}
 	}
 
-	// default is WARN
+	// default is INFO
 	t.Run("default", func(t *testing.T) {
-		treefmt(t, withNoError(t), withStderr(checkOutput(log.WarnLevel)))
+		treefmt(t, withArgs("-v"), withNoError(t), withStderr(checkOutput(log.InfoLevel)))
 	})
 
 	// should exit with error when using fatal

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -131,6 +131,33 @@ func TestOnUnmatched(t *testing.T) {
 	})
 }
 
+func TestQuiet(t *testing.T) {
+	as := require.New(t)
+	tempDir := test.TempExamples(t)
+
+	test.ChangeWorkDir(t, tempDir)
+
+	// allow missing formatter
+	t.Setenv("TREEFMT_ALLOW_MISSING_FORMATTER", "true")
+
+	noOutput := func(out []byte) {
+		as.Empty(out)
+	}
+
+	treefmt(t, withArgs("-q"), withNoError(t), withStdout(noOutput), withStderr(noOutput))
+	treefmt(t, withArgs("--quiet"), withNoError(t), withStdout(noOutput), withStderr(noOutput))
+
+	t.Setenv("TREEFMT_QUIET", "true")
+	treefmt(t, withNoError(t), withStdout(noOutput), withStderr(noOutput))
+
+	t.Setenv("TREEFMT_ALLOW_MISSING_FORMATTER", "false")
+
+	// check it doesn't suppress errors
+	treefmt(t, withError(func(err error) {
+		as.ErrorContains(err, "error looking up 'foo-fmt'")
+	}))
+}
+
 func TestCpuProfile(t *testing.T) {
 	as := require.New(t)
 	tempDir := test.TempExamples(t)

--- a/config/config.go
+++ b/config/config.go
@@ -89,7 +89,7 @@ func SetFlags(fs *pflag.FlagSet) {
 		"Ignore the evaluation cache entirely. Useful for CI. (env $TREEFMT_NO_CACHE)",
 	)
 	fs.StringP(
-		"on-unmatched", "u", "warn",
+		"on-unmatched", "u", "info",
 		"Log paths that did not match any formatters at the specified log level. Possible values are "+
 			"<debug|info|warn|error|fatal>. (env $TREEFMT_ON_UNMATCHED)",
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Formatters            []string `mapstructure:"formatters"              toml:"formatters,omitempty"`
 	NoCache               bool     `mapstructure:"no-cache"                toml:"-"` // not allowed in config
 	OnUnmatched           string   `mapstructure:"on-unmatched"            toml:"on-unmatched,omitempty"`
+	Quiet                 bool     `mapstructure:"quiet"                   toml:"-"` // not allowed in config
 	TreeRoot              string   `mapstructure:"tree-root"               toml:"tree-root,omitempty"`
 	TreeRootFile          string   `mapstructure:"tree-root-file"          toml:"tree-root-file,omitempty"`
 	Verbose               uint8    `mapstructure:"verbose"                 toml:"verbose,omitempty"`
@@ -109,6 +110,9 @@ func SetFlags(fs *pflag.FlagSet) {
 	fs.CountP(
 		"verbose", "v",
 		"Set the verbosity of logs e.g. -vv. (env $TREEFMT_VERBOSE)",
+	)
+	fs.BoolP(
+		"quiet", "q", false, "Disable all logs except errors. (env $TREEFMT_QUIET)",
 	)
 	fs.String(
 		"walk", "auto",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -323,6 +323,36 @@ func TestNoCache(t *testing.T) {
 	checkValue(true)
 }
 
+func TestQuiet(t *testing.T) {
+	as := require.New(t)
+
+	cfg := &config.Config{}
+	v, flags := newViper(t)
+
+	checkValue := func(expected bool) {
+		readValue(t, v, cfg, func(cfg *config.Config) {
+			as.Equal(expected, cfg.Quiet)
+		})
+	}
+
+	// default with no flag, env or config
+	checkValue(false)
+
+	// set config value and check that it has no effect
+	// you are not allowed to set no-cache in config
+	cfg.Quiet = true
+
+	checkValue(false)
+
+	// env override
+	t.Setenv("TREEFMT_QUIET", "false")
+	checkValue(false)
+
+	// flag override
+	as.NoError(flags.Set("quiet", "true"))
+	checkValue(true)
+}
+
 func TestOnUnmatched(t *testing.T) {
 	as := require.New(t)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -336,7 +336,7 @@ func TestOnUnmatched(t *testing.T) {
 	}
 
 	// default with no flag, env or config
-	checkValue("warn")
+	checkValue("info")
 
 	// set config value
 	cfg.OnUnmatched = "error"

--- a/docs/content/getting-started/configure.md
+++ b/docs/content/getting-started/configure.md
@@ -254,6 +254,22 @@ Possible values are `<debug|info|warn|error|fatal>`.
     on-unmatched = "debug"
     ```
 
+### `quiet`
+
+Suppress all output except for errors.
+
+=== "Flag"
+
+    ```console
+    treefmt --quiet
+    ```
+
+=== "Env"
+
+    ```console
+    TREEFMT_QUIET=true treefmt
+    ```
+
 ### `stdin`
 
 Format the context passed in via stdin.

--- a/docs/content/guides/unmatched-formatters.md
+++ b/docs/content/guides/unmatched-formatters.md
@@ -18,23 +18,28 @@ This helps you decide whether to add formatters for specific files or ignore the
 ## Customizing Notifications
 
 ### Reducing Log Verbosity
+
 If you find the unmatched file warnings too noisy, you can lower the logging level in your config:
 
 `treefmt.toml`:
+
 ```toml
 on-unmatched = "debug"
 ```
 
 To later find out what files are unmatched, you can override this setting via the command line:
+
 ```console
 $ treefmt --on-unmatched warn
 ```
 
 ### Enforcing Strict Matching
+
 Another stricter policy approach is to fail the run if any unmatched files are found.
 This can be paired with an `excludes` list to ignore specific files:
 
 `treefmt.toml`:
+
 ```toml
 # Fail if any unmatched files are found
 on-unmatched = "fatal"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: Treefmt
 site_url: https://treefmt.com
 site_description: >-
-  The formatter multiplexer.
+    The formatter multiplexer.
 
 # Repository
 repo_name: numtide/treefmt

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -34,7 +35,7 @@ func (s *Stats) Elapsed() time.Duration {
 	return time.Since(s.start)
 }
 
-func (s *Stats) Print() {
+func (s *Stats) PrintToStderr() {
 	components := []string{
 		"traversed %d files",
 		"emitted %d files for processing",
@@ -42,7 +43,8 @@ func (s *Stats) Print() {
 		"",
 	}
 
-	fmt.Printf(
+	_, _ = fmt.Fprintf(
+		os.Stderr,
 		strings.Join(components, "\n"),
 		s.Value(Traversed),
 		s.Value(Matched),


### PR DESCRIPTION
I've made some changes to how verbose we are being:

- **feat: log the config file used at DEBUG level instead of INFO**
- **feat: print stats to stderr instead of stdout**
- **feat: change default log level for unmatched to INFO instead of WARN**
- **feat: add a quiet flag to suppress all output except for errors**

Closes #501