### PR TITLE
feat: migrate to immediate processing

### DIFF
--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -183,6 +183,9 @@ func Run(v *viper.Viper, statz *stats.Stats, cmd *cobra.Command, paths []string)
 		if errors.Is(err, io.EOF) {
 			// we have finished traversing
 			break
+		} else if errors.Is(err, context.DeadlineExceeded) && cfg.Watch {
+			// we timed out reading files, try again
+			continue
 		} else if err != nil {
 			// something went wrong
 			return fmt.Errorf("failed to read files: %w", err)

--- a/format/composite.go
+++ b/format/composite.go
@@ -107,6 +107,8 @@ func (c *CompositeFormatter) Apply(ctx context.Context, files []*walk.File) erro
 		}
 	}
 
+	c.scheduler.apply(ctx)
+
 	return nil
 }
 

--- a/format/scheduler.go
+++ b/format/scheduler.go
@@ -203,14 +203,16 @@ func (s *scheduler) schedule(ctx context.Context, key batchKey, batch []*walk.Fi
 	})
 }
 
-func (s *scheduler) close(ctx context.Context) error {
+func (s *scheduler) apply(ctx context.Context) {
 	// schedule any partial batches that remain
 	for key, batch := range s.batches {
 		if len(batch) > 0 {
 			s.schedule(ctx, key, batch)
 		}
 	}
+}
 
+func (s *scheduler) close(ctx context.Context) error {
 	// wait for processing to complete
 	if err := s.eg.Wait(); err != nil {
 		return fmt.Errorf("failed to wait for formatters: %w", err)


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/numtide/treefmt/pull/511).
* #510
* __->__ #511