### PR TITLE
feat: add workflow to automatically update vendorHash

### DIFF
--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -1,0 +1,31 @@
+name: Update vendorHash
+on: pull_request
+
+permissions:
+    contents: write
+
+jobs:
+    dependabot:
+        runs-on: ubuntu-latest
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  fetch-depth: 0
+            - name: Install Nix
+              uses: cachix/install-nix-action@v31
+              with:
+                  github_access_token: ${{ secrets.GITHUB_TOKEN }}
+                  nix_path: nixpkgs=channel:nixos-unstable
+            - name: Update checksum
+              run: |
+                  nix run .#treefmt.update-vendor-hash                  
+                  # git push if we have a diff
+                  if [[ -n $(git diff) ]]; then
+                    git add default.nix
+                    git config --global user.email "<49699333+dependabot[bot]@users.noreply.github.com>"
+                    git config --global user.name "dependabot[bot]"
+                    git commit -m "update vendorHash"
+                    git push origin HEAD:${{ github.head_ref }}
+                  fi


### PR DESCRIPTION
I forgot when removing `gomod2nix` that we would need an automatic way of updating the vendor hash for renovate PRs. This adapts a pattern from https://github.com/Mic92/ssh-to-age/blob/main/.github/workflows/update-vendor-hash.yml