### PR TITLE
fix: update vendor hash workflow

### DIFF
--- a/.github/workflows/update-vendor-hash.yml
+++ b/.github/workflows/update-vendor-hash.yml
@@ -7,7 +7,7 @@ permissions:
 jobs:
     dependabot:
         runs-on: ubuntu-latest
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        if: ${{ github.actor == 'renovate[bot]' }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -24,8 +24,8 @@ jobs:
                   # git push if we have a diff
                   if [[ -n $(git diff) ]]; then
                     git add default.nix
-                    git config --global user.email "<49699333+dependabot[bot]@users.noreply.github.com>"
-                    git config --global user.name "dependabot[bot]"
+                    git config --global user.email "<29139614+renovate[bot]@users.noreply.github.com>"
+                    git config --global user.name "renovate[bot]"
                     git commit -m "update vendorHash"
                     git push origin HEAD:${{ github.head_ref }}
                   fi


### PR DESCRIPTION
It was targetting dependabot not renovatebot

Signed-off-by: Brian McGee <brian@bmcgee.ie>
