### PR TITLE
fix: shell completions

### DIFF
--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func generateShellCompletions(cmd *cobra.Command, args []string) error {
+	var err error
+
+	switch args[0] {
+	case "bash":
+		err = cmd.Root().GenBashCompletion(os.Stdout)
+	case "zsh":
+		err = cmd.Root().GenZshCompletion(os.Stdout)
+	case "fish":
+		err = cmd.Root().GenFishCompletion(os.Stdout, true)
+	default:
+		err = fmt.Errorf("unsupported shell: %s", args[0])
+	}
+
+	if err != nil {
+		err = fmt.Errorf("failed to generate shell completions: %w", err)
+	}
+
+	return err
+}

--- a/docs/content/getting-started/usage.md
+++ b/docs/content/getting-started/usage.md
@@ -14,6 +14,7 @@ Flags:
       --allow-missing-formatter   Do not exit with error if a configured formatter is missing. (env $TREEFMT_ALLOW_MISSING_FORMATTER)
       --ci                        Runs treefmt in a CI mode, enabling --no-cache, --fail-on-change and adjusting some other settings best suited to a CI use case. (env $TREEFMT_CI)
   -c, --clear-cache               Reset the evaluation cache. Use in case the cache is not precise enough. (env $TREEFMT_CLEAR_CACHE)
+      --completion string         [bash|zsh|fish] Generate shell completion scripts for the specified shell.
       --config-file string        Load the config file from the given path (defaults to searching upwards for treefmt.toml or .treefmt.toml).
       --cpu-profile string        The file into which a cpu profile will be written. (env $TREEFMT_CPU_PROFILE)
       --excludes strings          Exclude files or directories matching the specified globs. (env $TREEFMT_EXCLUDES)
@@ -124,6 +125,16 @@ output to `stdout`:
   };
 in
   flake.defaultNix
+```
+
+## Shell Completion
+
+To generate completions for your preferred shell:
+
+```console
+❯ treefmt --completion bash
+❯ treefmt --completion fish
+❯ treefmt --completion zsh
 ```
 
 ## CI integration

--- a/nix/packages/treefmt/default.nix
+++ b/nix/packages/treefmt/default.nix
@@ -47,7 +47,10 @@ in
     ];
 
     nativeBuildInputs =
-      [pkgs.git]
+      (with pkgs; [
+        git
+        installShellFiles
+      ])
       ++
       # we need some formatters available for the tests
       import ./formatters.nix pkgs;
@@ -61,6 +64,15 @@ in
       # setup a git user for committing during tests
       git config --global user.email "<test@treefmt.com>"
       git config --global user.name "Treefmt Test"
+    '';
+
+    postInstall = ''
+      export HOME=$PWD
+
+      installShellCompletion --cmd treefmt \
+          --bash <($out/bin/treefmt --completion bash) \
+          --fish <($out/bin/treefmt --completion fish) \
+          --zsh <($out/bin/treefmt --completion zsh)
     '';
 
     passthru = let


### PR DESCRIPTION
- disables default `completion` cobra sub-command
- adds a `--completion [bash|zsh|fish]` flag which will generate shell completions using cobra's built-in support
- adds `installShellCompletion` to the `treefmt` package (this will need added to the nixpkgs entry after release)

The completions are static and address the first half of #529.

Signed-off-by: Brian McGee <brian@bmcgee.ie>
