### PR TITLE
chore(flake): fix name + tagline

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Treefmt: once CLI to format your repo";
+  description = "treefmt: the formatter multiplexer";
 
   nixConfig = {
     extra-substituters = ["https://numtide.cachix.org"];


### PR DESCRIPTION
I've never seen the project called "Treefmt" anywhere, and we changed the tagline back in
https://github.com/numtide/treefmt/commit/5892f1abcdea99ebf46a011233670c046ed61757.