### PR TITLE
chore: remove remnants of `golangci-lint`

### DIFF
--- a/nix/devshells/default.nix
+++ b/nix/devshells/default.nix
@@ -9,7 +9,6 @@ pkgs.mkShellNoCC {
     (with pkgs; [
       go_1_24
       goreleaser
-      golangci-lint
       delve
       pprof
       graphviz

--- a/nix/packages/treefmt/default.nix
+++ b/nix/packages/treefmt/default.nix
@@ -111,17 +111,6 @@ in
             mv coverage.out $out
           '';
         }));
-
-        golangci-lint = treefmt.overrideAttrs (old: {
-          nativeBuildInputs = old.nativeBuildInputs ++ [pkgs.golangci-lint];
-          buildPhase = ''
-            HOME=$TMPDIR
-            golangci-lint run
-          '';
-          installPhase = ''
-            touch $out
-          '';
-        });
       };
     };
 


### PR DESCRIPTION
It looks like we stopped using `golangci-lint` in
https://github.com/numtide/treefmt/commit/3aaaf7c551590c4090059abdbab041d93bd89e86. Is there any reason to keep this stuff around?