### PR TITLE
feat: add `withConfig` & `buildConfig` from nixpkgs

### DIFF
--- a/nix/packages/treefmt/default.nix
+++ b/nix/packages/treefmt/default.nix
@@ -74,7 +74,19 @@ in
 
     passthru = let
       inherit (perSystem.self) treefmt;
+
+      # Inherits an attr from pkgs.treefmt, overriding the `treefmt` arg if possible
+      inheritFromNixpkgs = name: let
+        error = "Accessing `${name}` requires a nixpkgs revision that has `treefmt.${name}`.";
+        attr = pkgs.treefmt.${name} or (throw error);
+      in
+        if attr.override.__functionArgs.treefmt or null != null
+        then attr.override {inherit treefmt;}
+        else attr;
     in {
+      withConfig = inheritFromNixpkgs "withConfig";
+      buildConfig = inheritFromNixpkgs "buildConfig";
+
       no-vendor-hash = treefmt.overrideAttrs {
         vendorHash = "";
       };


### PR DESCRIPTION
Inherit the `withConfig` and `buildConfig` wrapper functions added in https://github.com/NixOS/nixpkgs/pull/390147

Fixes #558

If the current nixpkgs revision does not have these attrs, a sane error message is thrown when attempting to use them.

```
nix-repl> :lf .

nix-repl> packages.x86_64-linux.treefmt.withConfig
error:
       … while evaluating the attribute 'x86_64-linux.treefmt.withConfig'
       … while evaluating a branch condition

       error: Accessing `withConfig` requires a nixpkgs revision that has `treefmt.withConfig`.
```

I've tested this with and without `nix flake lock --override-input nixpkgs 'github:nixos/nixpkgs/nixos-unstable-small'`. With the newer nixpkgs revision the wrapper functions seem to work correctly.

The `treefmt` argument passed is overridden to refer to `perSystem.self.treefmt`.

I considered using `lib.genAttrs` to simplify the inheritence, however doing that with `//` caused the entire `passthru` to be indented by alejandra. I also considered using `inherit (lib.genAttrs)`, however this didn't seem much of an improvement:

```diff
diff --git a/nix/packages/treefmt/default.nix b/nix/packages/treefmt/default.nix
index 4db1258..59032b7 100644
--- a/nix/packages/treefmt/default.nix
+++ b/nix/packages/treefmt/default.nix
@@ -84,8 +84,15 @@ in
         then attr.override {inherit treefmt;}
         else attr;
     in {
-      withConfig = inheritFromNixpkgs "withConfig";
-      buildConfig = inheritFromNixpkgs "buildConfig";
+      inherit
+        (lib.genAttrs [
+            "withConfig"
+            "buildConfig"
+          ]
+          inheritFromNixpkgs)
+        withConfig
+        buildConfig
+        ;
 
       no-vendor-hash = treefmt.overrideAttrs {
         vendorHash = "";
```

I added some calls to `trace` to verify that the `treefmt` package argument is being correctly overridden:

```diff
diff --git a/nix/packages/treefmt/default.nix b/nix/packages/treefmt/default.nix
index 4db1258..51d2b59 100644
--- a/nix/packages/treefmt/default.nix
+++ b/nix/packages/treefmt/default.nix
@@ -81,8 +81,8 @@ in
         attr = pkgs.treefmt.${name} or (throw error);
       in
         if attr.override.__functionArgs.treefmt or null != null
-        then attr.override {inherit treefmt;}
-        else attr;
+        then builtins.trace "overriding" attr.override {inherit treefmt;}
+        else builtins.trace "not overriding" attr;
     in {
       withConfig = inheritFromNixpkgs "withConfig";
       buildConfig = inheritFromNixpkgs "buildConfig";
```

We see that `withConfig` overrides its `treefmt` arg, while `buildConfig` does not depend on `treefmt`:

```
nix-repl> :lf .

nix-repl> packages.x86_64-linux.treefmt.withConfig
trace: overriding

nix-repl> packages.x86_64-linux.treefmt.buildConfig
trace: not overriding
```
