### PR TITLE
Add a Stdin Specification

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2257,6 +2257,31 @@ help:
 `, string(out))
 		}),
 	)
+
+	// Format with embed-path. `embed-path` prefixes the file with its path. If
+	// this formatter didn't support the Stdin Specification, then we'd see a
+	// temp path get added instead of the true path to the file.
+	contents = `
+The formatter should add the path above this line.
+`
+	os.Stdin = test.TempFile(t, "", "stdin", &contents)
+
+	treefmt(t,
+		withArgs("-vvv", "--stdin", "path/to/foo.embed-path"),
+		withNoError(t),
+		withStats(t, map[stats.Type]int{
+			stats.Traversed: 1,
+			stats.Matched:   1,
+			stats.Formatted: 1,
+			stats.Changed:   1,
+		}),
+		withStdout(func(out []byte) {
+			as.Equal(`# path/to/foo.embed-path
+
+The formatter should add the path above this line.
+`, string(out))
+		}),
+	)
 }
 
 func TestDeterministicOrderingInPipeline(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2288,12 +2288,44 @@ help:
 		}),
 	)
 
+	// Format with embed-path. `embed-path` prefixes the file with its path. If
+	// this formatter didn't support the Stdin Specification, then we'd see a
+	// temp path get added instead of the true path to the file.
+	contents = `
+The formatter should add the path above this line.
+`
+	os.Stdin = test.TempFile(t, "", "stdin", &contents)
+
+	treefmt(t,
+		withArgs("-vvv", "--stdin", "path/to/foo.embed-path"),
+		withNoError(t),
+		withStats(t, map[stats.Type]int{
+			stats.Traversed: 1,
+			stats.Matched:   1,
+			stats.Formatted: 1,
+			stats.Changed:   1,
+		}),
+		withStdout(func(out []byte) {
+			as.Equal(`# path/to/foo.embed-path
+
+The formatter should add the path above this line.
+`, string(out))
+		}),
+	)
+
 	// Try from a subdirectory, using .. to get to a parent directory that is
 	// still inside the project root.
 	//
 	// Note: we called `test.ChangeWorkDir` at the start of the test, which
 	// will restore the working directory during test cleanup.
 	t.Chdir("go")
+
+	contents = `
+# print this message
+help:
+        just --list --list-submodules --unsorted
+
+`
 	os.Stdin = test.TempFile(t, "", "stdin", &contents)
 	treefmt(t,
 		withArgs("--stdin", "../foo/justfile"),
@@ -2821,6 +2853,14 @@ func treefmt(
 		os.Stdout = stdout
 		os.Stderr = stderr
 		log.SetOutput(stderr)
+	}()
+
+	// treefmt may change the configured log level when we invoke it. Be sure
+	// to restore the previous level.
+	ogLogLevel := log.GetLevel()
+
+	defer func() {
+		log.SetLevel(ogLogLevel)
 	}()
 
 	// run the command

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,12 @@ type Formatter struct {
 	Command string `mapstructure:"command" toml:"command"`
 	// Options are an optional list of args to be passed to Command.
 	Options []string `mapstructure:"options,omitempty" toml:"options,omitempty"`
+	// StdinOptions are an optional list of args used to invoke the formatter
+	// in stdin mode (where it reads the buffer to format from stdin rather
+	// than a file). Any occurrences of `$path` will be replaced with the "advisory path"
+	// of the "file" being formatted (useful for formatters whose behavior
+	// depend on the path of the file being formatted).
+	StdinOptions []string `mapstructure:"stdin-options,omitempty" toml:"stdin-options,omitempty"`
 	// Includes is a list of glob patterns used to determine whether this Formatter should be applied against a path.
 	Includes []string `mapstructure:"includes,omitempty" toml:"includes,omitempty"`
 	// Excludes is an optional list of glob patterns used to exclude certain files from this Formatter.

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ type Formatter struct {
 	Command string `mapstructure:"command" toml:"command"`
 	// Options are an optional list of args to be passed to Command.
 	Options []string `mapstructure:"options,omitempty" toml:"options,omitempty"`
-	// StringOptions are an optional list of args used to invoke the formatter
+	// StdinOptions are an optional list of args used to invoke the formatter
 	// in stdin mode (where it reads the buffer to format from stdin rather
 	// than a file). Any occurrences of `$path` will be replaced with the "advisory path"
 	// of the "file" being formatted (useful for formatters whose behavior

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,12 @@ type Formatter struct {
 	Command string `mapstructure:"command" toml:"command"`
 	// Options are an optional list of args to be passed to Command.
 	Options []string `mapstructure:"options,omitempty" toml:"options,omitempty"`
+	// StringOptions are an optional list of args used to invoke the formatter
+	// in stdin mode (where it reads the buffer to format from stdin rather
+	// than a file). Any occurrences of `$path` will be replaced with the "advisory path"
+	// of the "file" being formatted (useful for formatters whose behavior
+	// depend on the path of the file being formatted).
+	StdinOptions []string `mapstructure:"stdin-options,omitempty" toml:"stdin-options,omitempty"`
 	// Includes is a list of glob patterns used to determine whether this Formatter should be applied against a path.
 	Includes []string `mapstructure:"includes,omitempty" toml:"includes,omitempty"`
 	// Excludes is an optional list of glob patterns used to exclude certain files from this Formatter.

--- a/docs/site/getting-started/configure.md
+++ b/docs/site/getting-started/configure.md
@@ -460,6 +460,15 @@ The command to invoke when applying the formatter.
 
 An optional list of args to be passed to `command`.
 
+### `stdin-options`
+
+An optional list of args used to invoke the formatter in "stdin mode" (where it
+reads the buffer to format from stdin rather than a file). Any occurrences of
+`$path` will be replaced with the "advisory path" of the "file" being formatted.
+
+This is useful for formatters whose behavior depend on the path of the file being
+formatted.
+
 ### `includes`
 
 A list of [glob patterns](#glob-patterns-format) used to determine whether the formatter should be applied against a given path.

--- a/docs/site/getting-started/configure.md
+++ b/docs/site/getting-started/configure.md
@@ -460,6 +460,38 @@ The command to invoke when applying the formatter.
 
 An optional list of args to be passed to `command`.
 
+### `stdin-options`
+
+An optional list of args used to invoke the formatter in [Stdin Mode] (where it
+reads the buffer to format from stdin rather than a file). Any occurrences of
+`$path` will be replaced with the "advisory path" of the "virtual file" being
+formatted.
+
+This is useful for formatters whose behavior depend on the path of the file being
+formatted.
+
+See the [Stdin Spec] for more details.
+
+Examples:
+
+```toml
+[formatter.nixfmt]
+command = "nixfmt"
+includes = ["*.nix"]
+stdin-options = ["--stdin-filepath", "$path"]
+
+[formatter.buildifier]
+command = "buildifier"
+includes = ["BUILD", "*.bzl"]
+stdin-options = ["-path", "$path"]
+
+[formatter.ruff]
+command = "ruff"
+includes = ["BUILD", "*.bzl"]
+options = ["format"]
+stdin-options = ["format", "-"]
+```
+
 ### `includes`
 
 A list of [glob patterns](#glob-patterns-format) used to determine whether the formatter should be applied against a given path.
@@ -477,7 +509,7 @@ Influences the order of execution. Greater precedence is given to lower numbers,
 If `true`, `treefmt` will invoke the formatter with no more than 1 file at a time.
 
 Enable this if the formatter can only format 1 file at a time (a violation of
-[rule 1 of the formatter spec](https://treefmt.com/latest/reference/formatter-spec/#1-files-passed-as-arguments)).
+[rule 1 of the Formatter Spec]).
 
 ## Same file, multiple formatters?
 
@@ -505,7 +537,7 @@ selectors such as `*` and `?`.
 
 ## Supported Formatters
 
-Any formatter that follows the [spec] is supported out of the box.
+Any formatter that follows the [Formatter Spec] is supported out of the box.
 
 Already 60+ formatters are supported.
 
@@ -513,5 +545,8 @@ To find examples, take a look at <https://github.com/numtide/treefmt-nix/tree/ma
 
 If you are a Nix user, you might also like <https://github.com/numtide/treefmt-nix>, which uses Nix to pull in the right formatter package and seamlessly integrates both together.
 
-[spec]: ../reference/formatter-spec.md
+[Formatter Spec]: ../reference/formatter-spec.md
+[rule 1 of the Formatter Spec]: ../reference/formatter-spec.md#1-files-passed-as-arguments
+[Stdin Spec]: ../reference/stdin-spec.md
+[Stdin mode]: ../reference/stdin-spec.md#2-stdin-mode
 [TOML]: https://toml.io

--- a/docs/site/reference/formatter-spec.md
+++ b/docs/site/reference/formatter-spec.md
@@ -30,8 +30,8 @@ The formatter's CLI must be of the form:
 Where:
 
 - `<command>` is the name of the formatter executable.
-- `[options]` is any number of flags and options that the formatter accepts.
-- `[...<files>]` is one or more files given to the formatter for processing.
+- `[options]` are any number of flags and options that the formatter accepts.
+- `[...<files>]` are one or more files given to the formatter for processing.
 
 Example:
 
@@ -68,3 +68,10 @@ outputs.
 ### 5. Reliable
 
 We expect the formatter to be reliable and not break the semantics of the formatted files.
+
+### 6. Path agnostic
+
+The formatter _SHOULD_ be path agnostic (formatting _SHOULD NOT_ depend on the
+path of the file being formatted). If the formatter behaves differently based
+on the path of the file being formatted, then the formatter _MUST_ implement
+the [Stdin Specification](./stdin-spec.md).

--- a/docs/site/reference/stdin-spec.md
+++ b/docs/site/reference/stdin-spec.md
@@ -1,0 +1,57 @@
+---
+outline: deep
+---
+
+# Stdin Specification
+
+Formatters **MAY** also implement the Stdin Specification, which allows
+formatting "virtual files" passed via stdin.
+
+A formatter **MUST** implement the Stdin Specification if its formatting behavior
+can depend on the path of the file being formatted.
+
+## Rules
+
+In order for the formatter to comply with this spec, it **MUST** implement the
+vanilla [Formatter Specification](/reference/formatter-spec), and additionally
+satisfy the following:
+
+### 1. Command line option
+
+The formatter's CLI **MUST** have some cli option to activate stdin mode. The
+CLI _SHOULD_ accept an advisory path to make the formatter pretend stdin comes
+from this file. The formatter _MAY_ alter its behavior based on the given
+"advisory path" `<path>`. For example, if a there are different formatting
+rules in different directories, or just to include in error messages. If the
+formatter's behavior doesn't depend on the given `<path>`, it's ok to ignore
+it.
+
+The CLI option _SHOULD_ be called `--stdin-filepath`:
+
+```console
+$ echo "{}" | nixfmt --stdin-filepath path/to/file.nix
+```
+
+However, other options are OK, such as `-path`:
+
+```console
+$ echo 'print( "hello")' | buildifier -path foo.py
+```
+
+It's OK if the formatter doesn't accept an advisory path (which implies
+the formatter's behavior does not depend on file paths, which means the stdin
+specification is optional).
+
+```console
+$ echo 'print( "hello")' | ruff format -
+```
+
+### 2. Stdin mode
+
+When in stdin mode, the formatter:
+
+1. **MUST** print the formatted file to stdout.
+2. **MUST NOT** attempt to read the file on the filesystem. Instead, it
+   **MUST** read from stdin.
+3. **MUST NOT** write to the given path on the filesytem. It _MAY_ write to
+   temporary files elsewhere on disk, but _SHOULD_ clean them up when done.

--- a/docs/site/reference/stdin-spec.md
+++ b/docs/site/reference/stdin-spec.md
@@ -1,0 +1,69 @@
+---
+outline: deep
+---
+
+# Stdin Specification
+
+Formatters _MAY_ also implement the Stdin Specification, which allows
+formatting _virtual files_ passed via stdin.
+
+A formatter **MUST** implement the Stdin Specification if its formatting behavior
+can depend on the path of the file being formatted.
+
+## Terms
+
+- _virtual file_: Conceptually, represents some file the formatter is supposed to
+  treat "as if" it existed on disk. Concretely, a _virtual file_ is a buffer (passed via stdin)
+  and an _advisory path_ (passed as a CLI option).
+- _advisory path_: Represents the path of some _virtual file_. Called
+  "advisory" because it _MAY_ be passed to a formatter, and the formatter _MAY_
+  alter its behavior based on the given advisory path.
+
+## Rules
+
+In order for the formatter to comply with this spec, it **MUST** implement the
+vanilla [Formatter Specification](/reference/formatter-spec), and additionally
+satisfy the following:
+
+### 1. Command line option
+
+The formatter's CLI **MUST** have some option to activate [Stdin mode](#2-stdin-mode).
+
+The CLI _SHOULD_ accept an _advisory path_ to make the formatter pretend stdin comes
+from this file.
+
+The formatter _MAY_ alter its behavior based on the given
+_advisory path_ `<path>`. For example, if there are different formatting
+rules in different directories, or for use in error messages. If the
+formatter's behavior doesn't depend on the given `<path>`, it's ok to ignore
+it.
+
+The CLI option _SHOULD_ be called `--stdin-filepath`:
+
+```console
+$ echo "{}" | nixfmt --stdin-filepath path/to/file.nix
+```
+
+However, other options are OK, such as `-path`:
+
+```console
+$ echo 'print( "hello")' | buildifier -path foo.bzl
+```
+
+It's OK if the formatter does not accept an _advisory path_ (which implies
+the formatter's behavior does not depend on file paths, which means the Stdin
+Specification is optional).
+
+```console
+$ echo 'print( "hello")' | ruff format -
+```
+
+### 2. Stdin mode
+
+When in stdin mode, the formatter:
+
+1. **MUST** print the formatted file to stdout.
+2. **MUST NOT** attempt to read the file on the filesystem. Instead, it
+   **MUST** read from stdin.
+3. **MUST NOT** write to the given path on the filesytem. It _MAY_ write to
+   temporary files elsewhere on disk, but _SHOULD_ clean them up when done.

--- a/format/formatter.go
+++ b/format/formatter.go
@@ -107,12 +107,41 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 		return nil
 	}
 
-	// append paths to the args
-	for _, file := range files {
-		if file.TmpPath != "" {
-			args = append(args, file.TmpPath)
-		} else {
-			args = append(args, file.RelPath)
+	onlyFile := (*walk.File)(nil)
+	if len(files) == 1 {
+		onlyFile = files[0]
+	}
+
+	// If we have a TmpPath, that means we're formatting something other than the  file's RelPath
+	// mode". If the underlying formatter has its own stdin mode support, then
+	// we can invoke it in a way where we pass along the files's RelPath as an
+	// "advisory path", which may affect the behavior of the formatter.
+	useStdinMode := files[0].TmpPath != "" && f.config.StdinOptions != nil
+
+	stdin := (*os.File)(nil)
+
+	if useStdinMode {
+		// Feed the file to the formatter via stdin.
+		tmpFile, err := os.Open(onlyFile.TmpPath)
+		if err != nil {
+			panic(err)
+		}
+		defer tmpFile.Close()
+
+		stdin = tmpFile
+
+		replacer := strings.NewReplacer("$path", onlyFile.RelPath)
+		for _, arg := range f.config.StdinOptions {
+			args = append(args, replacer.Replace(arg))
+		}
+	} else {
+		// append paths to the args
+		for _, file := range files {
+			if file.TmpPath != "" {
+				args = append(args, file.TmpPath)
+			} else {
+				args = append(args, file.RelPath)
+			}
 		}
 	}
 
@@ -123,11 +152,13 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 		return cmd.Process.Signal(os.Interrupt)
 	}
 	cmd.Dir = f.workingDir
+	cmd.Stdin = stdin
 
 	// log out the command being executed
 	f.log.Debugf("executing: %s", cmd.String())
 
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		f.log.Errorf("failed to apply with options '%v': %s", f.config.Options, err)
 
 		if len(out) > 0 {
@@ -135,6 +166,16 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 		}
 
 		return fmt.Errorf("formatter '%s' with options '%v' failed to apply: %w", f.config.Command, f.config.Options, err)
+	}
+
+	// In stdin mode, the formatter won't write to the filesystem, it instead
+	// prints the formatted file to stdout. Take that output and write it back
+	// to the input file (`TmpPath`).
+	if useStdinMode {
+		path := onlyFile.TmpPath
+		if err = os.WriteFile(path, out, 0o600); err != nil {
+			return fmt.Errorf("couldn't write to '%s'", path)
+		}
 	}
 
 	f.log.Infof("%v file(s) processed in %v", len(files), time.Since(start))

--- a/format/formatter.go
+++ b/format/formatter.go
@@ -107,12 +107,41 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 		return nil
 	}
 
-	// append paths to the args
-	for _, file := range files {
-		if file.TmpPath != "" {
-			args = append(args, file.TmpPath)
-		} else {
-			args = append(args, file.RelPath)
+	onlyFile := (*walk.File)(nil)
+	if len(files) == 1 {
+		onlyFile = files[0]
+	}
+
+	// If we have a TmpPath, that means we're formatting something other than
+	// the file's RelPath. If the underlying formatter has its own stdin mode support, then
+	// we can invoke it in a way where we pass along the files's RelPath as an
+	// "advisory path", which may affect the behavior of the formatter.
+	useStdinMode := files[0].TmpPath != "" && f.config.StdinOptions != nil
+
+	stdin := (*os.File)(nil)
+
+	if useStdinMode {
+		// Feed the file to the formatter via stdin.
+		tmpFile, err := os.Open(onlyFile.TmpPath)
+		if err != nil {
+			panic(err)
+		}
+		defer tmpFile.Close()
+
+		stdin = tmpFile
+
+		replacer := strings.NewReplacer("$path", onlyFile.RelPath)
+		for _, arg := range f.config.StdinOptions {
+			args = append(args, replacer.Replace(arg))
+		}
+	} else {
+		// append paths to the args
+		for _, file := range files {
+			if file.TmpPath != "" {
+				args = append(args, file.TmpPath)
+			} else {
+				args = append(args, file.RelPath)
+			}
 		}
 	}
 
@@ -123,11 +152,13 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 		return cmd.Process.Signal(os.Interrupt)
 	}
 	cmd.Dir = f.workingDir
+	cmd.Stdin = stdin
 
 	// log out the command being executed
 	f.log.Debugf("executing: %s", cmd.String())
 
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		f.log.Errorf("failed to apply with options '%v': %s", f.config.Options, err)
 
 		if len(out) > 0 {
@@ -135,6 +166,16 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 		}
 
 		return fmt.Errorf("formatter '%s' with options '%v' failed to apply: %w", f.config.Command, f.config.Options, err)
+	}
+
+	// In stdin mode, the formatter won't write to the filesystem, it instead
+	// prints the formatted file to stdout. Take that output and write it back
+	// to the input file (`TmpPath`).
+	if useStdinMode {
+		path := onlyFile.TmpPath
+		if err = os.WriteFile(path, out, 0o600); err != nil {
+			return fmt.Errorf("couldn't write to '%s'", path)
+		}
 	}
 
 	f.log.Infof("%v file(s) processed in %v", len(files), time.Since(start))

--- a/nix/packages/treefmt/formatters.nix
+++ b/nix/packages/treefmt/formatters.nix
@@ -69,4 +69,35 @@ with pkgs; [
       test-fmt-append "suffix" "$1"
     '';
   })
+  (pkgs.writeShellApplication {
+    name = "test-fmt-embed-path";
+    text = ''
+      stdin_filepath=""
+      while [[ $# -gt 0 ]]; do
+        case $1 in
+            --stdin-filepath)
+                shift
+                stdin_filepath=$1
+                shift
+                ;;
+            --* | -*)
+                echo "Unknown option $1" >&2
+                exit 1
+                ;;
+            *)
+                echo "Unknown positional argument $1" >&2
+                exit 1
+                ;;
+        esac
+      done
+
+      if [ -z "$stdin_filepath" ]; then
+          echo "I only support stdin mode (use --stdin-filepath [path/to/file])." >&2
+          exit 1
+      fi
+
+      echo "# $stdin_filepath"
+      cat /dev/stdin
+    '';
+  })
 ]

--- a/test/examples/treefmt.toml
+++ b/test/examples/treefmt.toml
@@ -94,3 +94,8 @@ command = "foo-fmt"
 command = "just"
 options = ["--fmt", "--unstable", "--justfile"]
 includes = ["**/justfile"]
+
+[formatter.embed-path]
+command = "test-fmt-embed-path"
+includes = ["*.embed-path"]
+stdin-options = ["--stdin-filepath", "$path"]


### PR DESCRIPTION
This described the Stdin Specification, and adds a new `formatter.stdin_options` config to enable treefmt to invoke formatters in "stdin mode".