### PR TITLE
feat: add `evalConfig` from nixpkgs

### DIFF
--- a/nix/packages/treefmt/default.nix
+++ b/nix/packages/treefmt/default.nix
@@ -84,6 +84,7 @@ in
         then attr.override {inherit treefmt;}
         else attr;
     in {
+      evalConfig = inheritFromNixpkgs "evalConfig";
       withConfig = inheritFromNixpkgs "withConfig";
       buildConfig = inheritFromNixpkgs "buildConfig";
 


### PR DESCRIPTION
This is required by `buildConfig` and `withConfig` since https://github.com/NixOS/nixpkgs/pull/406685.
