### PR TITLE
refactor: simplify one line of nix code

### DIFF
--- a/nix/packages/treefmt/default.nix
+++ b/nix/packages/treefmt/default.nix
@@ -80,7 +80,7 @@ in
         error = "Accessing `${name}` requires a nixpkgs revision that has `treefmt.${name}`.";
         attr = pkgs.treefmt.${name} or (throw error);
       in
-        if attr.override.__functionArgs.treefmt or null != null
+        if attr ? override.__functionArgs.treefmt
         then attr.override {inherit treefmt;}
         else attr;
     in {


### PR DESCRIPTION
Sorry, this was bugging me last time I looked at this code.

We don't actually care if `__functionArgs.treefmt` is null (it'll always be `true` or `false`). We actually care if the attr is present.

IIRC, when I first wrote that line I didn't know you could use a nested attrpath on the RHS of the `?` operator, so I resorted to misusing `or` instead.
