### PR TITLE
feat: add jujutsu walker

### DIFF
--- a/cmd/init/init.toml
+++ b/cmd/init/init.toml
@@ -48,7 +48,7 @@
 # verbose = 2
 
 # The method used to traverse the files within the tree root
-# Currently, we support 'auto', 'git' or 'filesystem'
+# Currently, we support 'auto', 'git', 'jujutsu', or 'filesystem'
 # Env $TREEFMT_WALK
 # walk = "filesystem"
 

--- a/docs/site/getting-started/configure.md
+++ b/docs/site/getting-started/configure.md
@@ -317,8 +317,13 @@ If you wish to pass arguments containing quotes, you should use nested quotes e.
     If [walk](#walk) is set to `git` and no tree root option has been defined, `tree-root-cmd` will be defaulted to
     `git rev-parse --show-toplevel`.
 
+    If [walk](#walk) is set to `jujutsu` and no tree root option has been defined, `tree-root-cmd` will be defaulted to
+    `jj workspace root`.
+
     if [walk](#walk) is set to `auto` (the default), `treefmt` will check if the [working directory](#working-dir) is
-    inside a git worktree. If it is, `tree-root-cmd` will be defaulted as described above for `git`.
+    inside a git worktree. If it is, `tree-root-cmd` will be defaulted as described above for `git`. If the [working
+    directory](#working-dir) is inside a jujutsu worktree the `tree-root-cmd` will be defaulted as described above for
+    `jujutsu`.
 
 === "Flag"
 
@@ -391,7 +396,7 @@ Set the verbosity level of logs:
 ### `walk`
 
 The method used to traverse the files within the tree root.
-Currently, we support 'auto', 'git' or 'filesystem'
+Currently, we support 'auto', 'git', 'jujutsu' or 'filesystem'
 
 === "Flag"
 

--- a/jujutsu/jujutsu.go
+++ b/jujutsu/jujutsu.go
@@ -1,0 +1,28 @@
+package jujutsu
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const TreeRootCmd = "jj workspace root"
+
+func IsInsideWorktree(path string) (bool, error) {
+	// check if the root is a jujutsu repository
+	cmd := exec.Command("jj", "workspace", "root")
+	cmd.Dir = path
+
+	err := cmd.Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && strings.Contains(string(exitErr.Stderr), "There is no jj repo in \".\"") {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to check if %s is a jujutsu repository: %w", path, err)
+	}
+	// is a jujutsu repo
+	return true, nil
+}

--- a/nix/packages/treefmt/default.nix
+++ b/nix/packages/treefmt/default.nix
@@ -46,6 +46,7 @@ in
     nativeBuildInputs =
       (with pkgs; [
         git
+        jujutsu
         installShellFiles
       ])
       ++

--- a/test/config/jj/config.toml
+++ b/test/config/jj/config.toml
@@ -1,0 +1,2 @@
+[signing]
+backend = "none"

--- a/test/test.go
+++ b/test/test.go
@@ -14,6 +14,17 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func SetenvXdgConfigDir(t *testing.T) {
+	t.Helper()
+
+	configPath, err := filepath.Abs("../test/config")
+	if err != nil {
+		t.Fatalf("failed to get the path to the config directory: %v", err)
+	}
+
+	t.Setenv("XDG_CONFIG_HOME", configPath)
+}
+
 func WriteConfig(t *testing.T, path string, cfg *config.Config) {
 	t.Helper()
 

--- a/walk/jujutsu.go
+++ b/walk/jujutsu.go
@@ -1,0 +1,172 @@
+package walk
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/charmbracelet/log"
+	"github.com/numtide/treefmt/v2/jujutsu"
+	"github.com/numtide/treefmt/v2/stats"
+	"golang.org/x/sync/errgroup"
+)
+
+type JujutsuReader struct {
+	root string
+	path string
+
+	log   *log.Logger
+	stats *stats.Stats
+
+	eg      *errgroup.Group
+	scanner *bufio.Scanner
+}
+
+func (j *JujutsuReader) Read(ctx context.Context, files []*File) (n int, err error) {
+	// ensure we record how many files we traversed
+	defer func() {
+		j.stats.Add(stats.Traversed, n)
+	}()
+
+	if j.scanner == nil {
+		// create a pipe to capture the command output
+		r, w := io.Pipe()
+
+		// create a command which will execute from root
+		// --ignore-working-copy: Don't snapshot the working copy, and don't update it. This prevents that the user has to
+		// enter a password for singning the commit. New files also won't be added to the index and not displayed in the
+		// output.
+		// Add the subpath as a fileset displaying only files matching this prefix. If
+		// the subpath is empty ignore it since it interferese with command
+		args := []string{"file", "list", "--ignore-working-copy"}
+		if j.path != "" {
+			args = append(args, j.path)
+		}
+
+		cmd := exec.Command("jj", args...)
+		cmd.Dir = j.root
+		cmd.Stdout = w
+
+		// execute the command in the background
+		j.eg.Go(func() error {
+			return w.CloseWithError(cmd.Run())
+		})
+
+		// create a new scanner for reading the output
+		j.scanner = bufio.NewScanner(r)
+	}
+
+	nextLine := func() (string, error) {
+		line := j.scanner.Text()
+
+		if len(line) == 0 || line[0] != '"' {
+			return line, nil
+		}
+
+		unquoted, err := strconv.Unquote(line)
+		if err != nil {
+			return "", fmt.Errorf("failed to unquote line %s: %w", line, err)
+		}
+
+		return unquoted, nil
+	}
+
+LOOP:
+
+	for n < len(files) {
+		select {
+		// exit early if the context was cancelled
+		case <-ctx.Done():
+			err = ctx.Err()
+			if err == nil {
+				return n, fmt.Errorf("context cancelled: %w", ctx.Err())
+			}
+
+			return n, nil
+
+		default:
+			// read the next file
+			if j.scanner.Scan() {
+				entry, err := nextLine()
+				if err != nil {
+					return n, err
+				}
+
+				path := filepath.Join(j.root, entry)
+
+				j.log.Debugf("processing file: %s", path)
+
+				info, err := os.Lstat(path)
+
+				switch {
+				case os.IsNotExist(err):
+					// the underlying file might have been removed
+					j.log.Warnf(
+						"Path %s is in the worktree but appears to have been removed from the filesystem", path,
+					)
+
+					continue
+				case err != nil:
+					return n, fmt.Errorf("failed to stat %s: %w", path, err)
+				case info.Mode()&os.ModeSymlink == os.ModeSymlink:
+					// we skip reporting symlinks stored in Jujutsu, they should
+					// point to local files which we would list anyway.
+					continue
+				}
+
+				files[n] = &File{
+					Path:    path,
+					RelPath: entry,
+					Info:    info,
+				}
+
+				n++
+			} else {
+				// nothing more to read
+				err = io.EOF
+
+				break LOOP
+			}
+		}
+	}
+
+	return n, err
+}
+
+func (j *JujutsuReader) Close() error {
+	err := j.eg.Wait()
+	if err != nil {
+		return fmt.Errorf("failed to wait for jujutsu command to complete: %w", err)
+	}
+
+	return nil
+}
+
+func NewJujutsuReader(
+	root string,
+	path string,
+	statz *stats.Stats,
+) (*JujutsuReader, error) {
+	// check if the root is a jujutsu repository
+	isJujutsu, err := jujutsu.IsInsideWorktree(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if %s is a jujutsu repository: %w", root, err)
+	}
+
+	if !isJujutsu {
+		return nil, fmt.Errorf("%s is not a jujutsu repository", root)
+	}
+
+	return &JujutsuReader{
+		root:  root,
+		path:  path,
+		stats: statz,
+		eg:    &errgroup.Group{},
+		log:   log.WithPrefix("walk | jujutsu"),
+	}, nil
+}

--- a/walk/jujutsu.go
+++ b/walk/jujutsu.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 
 	"github.com/charmbracelet/log"
 	"github.com/numtide/treefmt/v2/jujutsu"
@@ -61,19 +60,10 @@ func (j *JujutsuReader) Read(ctx context.Context, files []*File) (n int, err err
 		j.scanner = bufio.NewScanner(r)
 	}
 
-	nextLine := func() (string, error) {
+	nextLine := func() string {
 		line := j.scanner.Text()
 
-		if len(line) == 0 || line[0] != '"' {
-			return line, nil
-		}
-
-		unquoted, err := strconv.Unquote(line)
-		if err != nil {
-			return "", fmt.Errorf("failed to unquote line %s: %w", line, err)
-		}
-
-		return unquoted, nil
+		return line
 	}
 
 LOOP:
@@ -92,10 +82,7 @@ LOOP:
 		default:
 			// read the next file
 			if j.scanner.Scan() {
-				entry, err := nextLine()
-				if err != nil {
-					return n, err
-				}
+				entry := nextLine()
 
 				path := filepath.Join(j.root, entry)
 

--- a/walk/jujutsu_test.go
+++ b/walk/jujutsu_test.go
@@ -1,0 +1,75 @@
+package walk_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/numtide/treefmt/v2/stats"
+	"github.com/numtide/treefmt/v2/test"
+	"github.com/numtide/treefmt/v2/walk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJujutsuReader(t *testing.T) {
+	as := require.New(t)
+
+	test.SetenvXdgConfigDir(t)
+	tempDir := test.TempExamples(t)
+
+	// init a jujutsu repo
+	cmd := exec.Command("jj", "git", "init")
+	cmd.Dir = tempDir
+	as.NoError(cmd.Run(), "failed to init jujutsu repository")
+
+	// read empty worktree
+	statz := stats.New()
+	reader, err := walk.NewJujutsuReader(tempDir, "", &statz)
+	as.NoError(err)
+
+	files := make([]*walk.File, 33) // The number of files in `test/examples` used for testing
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	n, err := reader.Read(ctx, files)
+
+	// Jujutsu depends on updating the index with a `jj` command. So, until we do
+	// that, the walker should return nothing, since the walker is executed with
+	// `--ignore-working-copy` which does not update the index.
+	cancel()
+	as.Equal(0, n)
+	as.ErrorIs(err, io.EOF)
+
+	// update jujutsu's index
+	cmd = exec.Command("jj")
+	cmd.Dir = tempDir
+	as.NoError(cmd.Run(), "failed to update the index")
+
+	statz = stats.New()
+	reader, err = walk.NewJujutsuReader(tempDir, "", &statz)
+	as.NoError(err)
+
+	count := 0
+
+	for {
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+
+		files := make([]*walk.File, 8)
+		n, err := reader.Read(ctx, files)
+
+		count += n
+
+		cancel()
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+	}
+
+	as.Equal(32, count)
+	as.Equal(32, statz.Value(stats.Traversed))
+	as.Equal(0, statz.Value(stats.Matched))
+	as.Equal(0, statz.Value(stats.Formatted))
+	as.Equal(0, statz.Value(stats.Changed))
+}

--- a/walk/type_enum.go
+++ b/walk/type_enum.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _TypeName = "autostdinfilesystemgit"
+const _TypeName = "autostdinfilesystemgitjujutsu"
 
-var _TypeIndex = [...]uint8{0, 4, 9, 19, 22}
+var _TypeIndex = [...]uint8{0, 4, 9, 19, 22, 29}
 
-const _TypeLowerName = "autostdinfilesystemgit"
+const _TypeLowerName = "autostdinfilesystemgitjujutsu"
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_TypeIndex)-1) {
@@ -28,9 +28,10 @@ func _TypeNoOp() {
 	_ = x[Stdin-(1)]
 	_ = x[Filesystem-(2)]
 	_ = x[Git-(3)]
+	_ = x[Jujutsu-(4)]
 }
 
-var _TypeValues = []Type{Auto, Stdin, Filesystem, Git}
+var _TypeValues = []Type{Auto, Stdin, Filesystem, Git, Jujutsu}
 
 var _TypeNameToValueMap = map[string]Type{
 	_TypeName[0:4]:        Auto,
@@ -41,6 +42,8 @@ var _TypeNameToValueMap = map[string]Type{
 	_TypeLowerName[9:19]:  Filesystem,
 	_TypeName[19:22]:      Git,
 	_TypeLowerName[19:22]: Git,
+	_TypeName[22:29]:      Jujutsu,
+	_TypeLowerName[22:29]: Jujutsu,
 }
 
 var _TypeNames = []string{
@@ -48,6 +51,7 @@ var _TypeNames = []string{
 	_TypeName[4:9],
 	_TypeName[9:19],
 	_TypeName[19:22],
+	_TypeName[22:29],
 }
 
 // TypeString retrieves an enum value from the enum constants string name.

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -25,6 +25,7 @@ const (
 	Stdin
 	Filesystem
 	Git
+	Jujutsu
 
 	BatchSize = 1024
 )
@@ -205,10 +206,13 @@ func NewReader(
 
 	switch walkType {
 	case Auto:
-		// for now, we keep it simple and try git first, filesystem second
+		// for now, we keep it simple and try git first, jujutsu second, and filesystem last
 		reader, err = NewReader(Git, root, path, db, statz)
 		if err != nil {
-			reader, err = NewReader(Filesystem, root, path, db, statz)
+			reader, err = NewReader(Jujutsu, root, path, db, statz)
+			if err != nil {
+				reader, err = NewReader(Filesystem, root, path, db, statz)
+			}
 		}
 
 		return reader, err
@@ -218,6 +222,8 @@ func NewReader(
 		reader = NewFilesystemReader(root, path, statz, BatchSize)
 	case Git:
 		reader, err = NewGitReader(root, path, statz)
+	case Jujutsu:
+		reader, err = NewJujutsuReader(root, path, statz)
 
 	default:
 		return nil, fmt.Errorf("unknown walk type: %v", walkType)


### PR DESCRIPTION
This PR introduces a new Jujutsu walker to numtide/treefmt, modeled after the existing Git walker but tailored to Jujutsu repositories. Key differences include:

- The list command does not update the index automatically, so untracked files must be explicitly added via `jj` commands.

This addition enables proper handling of Jujutsu ignore rules without requiring co-located Git repos, improving integration and file traversal accuracy for Jujutsu users.

I lack Go experience and primarily copied, and adapted the existing Git walker by adjusting commands. I would welcome guidance or collaboration to develop a more idiomatic and robust implementation.
