### PR TITLE
chore: fix flaky tests

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1382,7 +1382,6 @@ func TestGit(t *testing.T) {
 	as.NoError(gitCmd.Run(), "failed to add everything to the index")
 
 	treefmt(t,
-		withConfig(configPath, cfg),
 		withNoError(t),
 		withStats(t, map[stats.Type]int{
 			stats.Traversed: 33,
@@ -1401,7 +1400,6 @@ func TestGit(t *testing.T) {
 	})
 
 	treefmt(t,
-		withConfig(configPath, cfg),
 		withNoError(t),
 		withStats(t, map[stats.Type]int{
 			stats.Traversed: 33,
@@ -1417,7 +1415,6 @@ func TestGit(t *testing.T) {
 	// we should traverse and match against fewer files, but no formatting should occur as no formatting signatures
 	// are impacted
 	treefmt(t,
-		withConfig(configPath, cfg),
 		withNoError(t),
 		withStats(t, map[stats.Type]int{
 			stats.Traversed: 30,
@@ -1436,7 +1433,6 @@ func TestGit(t *testing.T) {
 	// traverse 82 files.
 	treefmt(t,
 		withArgs("--walk", "filesystem"),
-		withConfig(configPath, cfg),
 		withNoError(t),
 		withStats(t, map[stats.Type]int{
 			stats.Traversed: 82,
@@ -1605,7 +1601,6 @@ func TestJujutsu(t *testing.T) {
 	})
 
 	treefmt(t,
-		withConfig(configPath, cfg),
 		withNoError(t),
 		withStats(t, map[stats.Type]int{
 			stats.Traversed: 33,
@@ -1625,7 +1620,6 @@ func TestJujutsu(t *testing.T) {
 	// we should traverse and match against fewer files, but no formatting should occur as no formatting signatures
 	// are impacted
 	treefmt(t,
-		withConfig(configPath, cfg),
 		withNoError(t),
 		withStats(t, map[stats.Type]int{
 			stats.Traversed: 30,
@@ -1644,7 +1638,6 @@ func TestJujutsu(t *testing.T) {
 	// traverse 130 files.
 	treefmt(t,
 		withArgs("--walk", "filesystem"),
-		withConfig(configPath, cfg),
 		withNoError(t),
 		withStats(t, map[stats.Type]int{
 			stats.Traversed: 133,

--- a/test/test.go
+++ b/test/test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
@@ -60,14 +59,9 @@ func WriteConfig(t *testing.T, path string, cfg *config.Config) {
 	// Note: we're comparing `Unix()` (which is only 1 second granularity) for consistency with
 	// `walk.go::formatSignature`.
 	if oldInfo != nil && oldInfo.ModTime().Unix() == newInfo.ModTime().Unix() {
-		// No change to atime.
-		sysStat, ok := newInfo.Sys().(*syscall.Stat_t)
-		if !ok {
-			t.Fatalf("failed to cast stat Sys")
-		}
-
-		atime := sysStat.Atim
-		newAtime := time.Unix(atime.Sec, atime.Nsec)
+		// Ideally we wouldn't change the atime at all, but it's hard to fetch
+		// the original atime in a cross-platform manner.
+		newAtime := time.Now()
 
 		// Increase the mtime so it's different.
 		newMtime := oldInfo.ModTime().Add(time.Second)


### PR DESCRIPTION
I found that `TestGit` (and `TestJujutsu`, which was copied from `TestGit`) were failing intermittently. This took me some time to track down: the issue is an interaction between a few things:

- This test configures a formatter to run on all files (`"*"`), which importantly includes the `treefmt.toml` file at the root of the temp test project
- This test invokes treefmt with `withConfig(configPath, cfg)`. Under the hood, `withConfig` always writes to the `treefmt.toml` config file, which (possibly) means updating the mtime of `treefmt.toml` file.
- treefmt computes cache signatures using mtimes at 1-second granularity (presumably because this the only cross filesystem compatible option).

In effect, if the test ran quickly (under 1 second), then `treefmt.toml` would get formatted exactly 1 time on the first invocation of treefmt. However, if the test ran slow enough that the mtime actually changed throughout the test, then `treefmt.toml` would get formatted multiple times.

I could have fixed this in a few ways. I opted to remove the unnecessary calls to `withConfig(configPath, cfg)` sprinkled throughout the test. Furthermore, to make this less likely to recur, I changed `WriteConfig` to ensure that the resulting file *always* has a new mtime, even if this requires setting it to the future.