### PR TITLE
fix: normalize path separators for Windows compatibility

### DIFF
--- a/format/glob.go
+++ b/format/glob.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gobwas/glob"
 )
@@ -23,6 +24,8 @@ func compileGlobs(patterns []string) ([]glob.Glob, error) {
 }
 
 func pathMatches(path string, globs []glob.Glob) bool {
+	path = strings.ReplaceAll(path, "\\", "/")
+
 	for idx := range globs {
 		if globs[idx].Match(path) {
 			return true


### PR DESCRIPTION
On Windows, file paths use backslashes (`\`) as separators. The `gobwas/glob` library expects forward slashes, so glob matching would silently fail for all Windows paths. This fix normalizes backslashes to forward slashes in pathMatches before matching, making formatter glob patterns work correctly on Windows. Tested on Windows 11.

By the way: It seems like the library is not officially released on Windows. We use pixi and download `treefmt` from `conda-forge` which has for some reason a win-64 binary available.