### PR TITLE
fix: don't append `options` and `stdin-options`

### DIFF
--- a/format/formatter.go
+++ b/format/formatter.go
@@ -99,9 +99,6 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 
 	start := time.Now()
 
-	// construct args, starting with config
-	args := f.config.Options
-
 	// exit early if nothing to process
 	if len(files) == 0 {
 		return nil
@@ -120,6 +117,9 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 
 	stdin := (*os.File)(nil)
 
+	// construct args, starting with config
+	args := []string{}
+
 	if useStdinMode {
 		// Feed the file to the formatter via stdin.
 		tmpFile, err := os.Open(onlyFile.TmpPath)
@@ -135,6 +135,8 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 			args = append(args, replacer.Replace(arg))
 		}
 	} else {
+		args = append(args, f.config.Options...)
+
 		// append paths to the args
 		for _, file := range files {
 			if file.TmpPath != "" {
@@ -159,13 +161,13 @@ func (f *Formatter) Apply(ctx context.Context, files []*walk.File) error {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		f.log.Errorf("failed to apply with options '%v': %s", f.config.Options, err)
+		f.log.Errorf("failed to apply with options '%v': %s", args, err)
 
 		if len(out) > 0 {
 			_, _ = fmt.Fprintf(os.Stderr, "\n%s\n", out)
 		}
 
-		return fmt.Errorf("formatter '%s' with options '%v' failed to apply: %w", f.config.Command, f.config.Options, err)
+		return fmt.Errorf("formatter '%s' with options '%v' failed to apply: %w", f.config.Command, args, err)
 	}
 
 	// In stdin mode, the formatter won't write to the filesystem, it instead

--- a/nix/packages/treefmt/formatters.nix
+++ b/nix/packages/treefmt/formatters.nix
@@ -72,8 +72,20 @@ with pkgs; [
   (pkgs.writeShellApplication {
     name = "test-fmt-embed-path";
     text = ''
+      if [ $# -eq 0 ]; then
+        echo "Must provide a subcommand" >&2
+        exit 1
+      fi
+
+      subcommand=$1
+      shift
+      if [ "$subcommand" != "fmt" ]; then
+        echo "Unknown subcommand $subcommand" >&2
+        exit 1
+      fi
+
       stdin_filepath=""
-      while [[ $# -gt 0 ]]; do
+      while [ $# -gt 0 ]; do
         case $1 in
             --stdin-filepath)
                 shift

--- a/test/examples/treefmt.toml
+++ b/test/examples/treefmt.toml
@@ -98,4 +98,5 @@ includes = ["**/justfile"]
 [formatter.embed-path]
 command = "test-fmt-embed-path"
 includes = ["*.embed-path"]
-stdin-options = ["--stdin-filepath", "$path"]
+options = [ "fmt" ]
+stdin-options = ["fmt", "--stdin-filepath", "$path"]


### PR DESCRIPTION
For maximal flexibility, they are supposed to be completely independent. Unfortunately, the test I added left `options` as `[]`, which meant we didn't notice this bug. I've expanded the test accordingly.

This fixes https://github.com/numtide/treefmt/issues/718.