### PR TITLE
docs: correct on-unmatched env var name (TREEFMT_ON_UNMACTHED -> TREEFMT_ON_UNMATCHED)

### DIFF
--- a/docs/site/getting-started/configure.md
+++ b/docs/site/getting-started/configure.md
@@ -245,7 +245,7 @@ Possible values are `<debug|info|warn|error|fatal>`.
 === "Env"
 
     ```console
-    TREEFMT_ON_UNMACTHED=info treefmt
+    TREEFMT_ON_UNMATCHED=info treefmt
     ```
 
 === "Config"


### PR DESCRIPTION
## Problem

The `on-unmatched` section of the configuration guide documents the environment variable with two letters transposed, so the documented variable is not the one treefmt reads.

`docs/site/getting-started/configure.md:248` (Env tab of `### on-unmatched`):

```console
TREEFMT_ON_UNMACTHED=info treefmt
```

The rest of the repo consistently uses the correct spelling — `git grep -n TREEFMT_ON_UNMATCHED`:

```
cmd/init/init.toml:27:# Env $TREEFMT_ON_UNMATCHED
cmd/root_test.go:90:            t.Setenv("TREEFMT_ON_UNMATCHED", "fatal")
cmd/root_test.go:107:                   t.Setenv("TREEFMT_ON_UNMATCHED", levelStr)
cmd/root_test.go:130:           t.Setenv("TREEFMT_ON_UNMATCHED", "bar")
config/config.go:118:                   "<debug|info|warn|error|fatal>. (env $TREEFMT_ON_UNMATCHED)",
config/config_test.go:410:      t.Setenv("TREEFMT_ON_UNMATCHED", "debug")
```

`TREEFMT_ON_UNMATCHED` is what viper derives from the flag name (`config/config.go:116` registers `on-unmatched`; `config/config.go:171-173` sets `SetEnvPrefix("treefmt")` + `NewReplacer("-", "_", ".", "_")`), which is the same derivation the sibling section at line 226 documents correctly for `TREEFMT_NO_CACHE`.

Two user-visible consequences:

* `treefmt --help` prints `(env $TREEFMT_ON_UNMATCHED)` while the guide says `TREEFMT_ON_UNMACTHED`.
* The published page <https://treefmt.com/latest/getting-started/configure/> contradicts itself: the embedded `init.toml` sample shows `# Env $TREEFMT_ON_UNMATCHED`, while the Env tab of the same page shows `TREEFMT_ON_UNMACTHED`.

Because the misspelled variable is simply not a treefmt setting, it is silently ignored — no warning, no error, no behaviour change.

## Change

One line in `docs/site/getting-started/configure.md`:

```diff
-    TREEFMT_ON_UNMACTHED=info treefmt
+    TREEFMT_ON_UNMATCHED=info treefmt
```

Nothing else is touched. `git grep -n UNMACTHED` returned exactly one hit before this change and zero after, so there is no alias or compatibility shim anywhere that this would break.

## Verification

**1. Existing unit test still passes (unchanged):**

```console
$ go test ./config/ -run TestOnUnmatched
ok      github.com/numtide/treefmt/v2/config    1.146s
```

**2. End-to-end proof that the documented name is a no-op.** Built `treefmt` from this branch, then ran it in a scratch repo containing `treefmt.toml` (no formatters configured) and `unmatched.txt`, so both files are unmatched. `fatal` was chosen because it has an unambiguous signal — a non-zero exit:

```console
$ TREEFMT_ON_UNMACTHED=fatal treefmt --no-cache      # the name the docs currently give
traversed 2 files
emitted 0 files for processing
formatted 0 files (0 changed) in 134ms
exit code = 0

$ TREEFMT_ON_UNMATCHED=fatal treefmt --no-cache      # the name after this change
traversed 2 files
emitted 0 files for processing
formatted 0 files (0 changed) in 115ms
Error: failed to format files: no formatter for path: treefmt.toml
exit code = 1
```

The currently documented variable has no effect at all; the corrected one is honoured.

## Limitations

Documentation only — no code change, and the rendered docs are not rebuilt here (`nix build .#docs` was not run, since the edit is a single word inside an existing fenced `console` block and does not affect layout or line length). Verification was performed on Windows with Go 1.26.1 rather than inside the Nix devshell; `go test ./cmd/ -run TestOnUnmatched`, which needs real formatters from the devshell, was therefore not run.

Commit is signed off per `.github/CONTRIBUTING.md` (DCO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
